### PR TITLE
Add support for "latest" driver option

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -35,8 +35,22 @@ fi
 _autoaddpatch="false"
 
 # Package type selector
-if [ -z "$_driver_version" ] || [ -z "$_driver_branch" ] && [ ! -e options ]; then
-  read -p "    What driver version do you want?`echo $'\n    > 1.Vulkan dev: 455.50.03\n      2.460 series: 460.39\n      3.455 series: 455.45.01\n      4.450 series: 450.102.04\n      5.440 series: 440.100 (kernel 5.8 or lower)\n      6.435 series: 435.21  (kernel 5.6 or lower)\n      7.430 series: 430.64  (kernel 5.5 or lower)\n      8.418 series: 418.113 (kernel 5.5 or lower)\n      9.415 series: 415.27  (kernel 5.4 or lower)\n      10.410 series: 410.104 (kernel 5.5 or lower)\n      11.396 series: 396.54  (kernel 5.3 or lower, 5.1 or lower recommended)\n      12.Custom version (396.xx series or higher)\n    choice[1-12?]: '`" CONDITION;
+if [ -z "$_driver_version" ] || [ "$_driver_version" = "latest" ] || [ -z "$_driver_branch" ] && [ ! -e options ]; then
+  # Unset this just in case another prompt using CONDITION is ever added before this code.
+  unset CONDITION
+  if [ "$_driver_version" = "latest" ]; then
+    if [ "$_driver_branch" = "regular" ]; then
+      CONDITION="2"
+    elif [ "$_driver_branch" = "vulkandev" ]; then
+      CONDITION="1"
+    else
+      error "\"latest\" driver specified, but without branch. Make sure _driver_branch is set."
+    fi
+  fi
+  if [[ -z $CONDITION ]]; then
+    read -p "    What driver version do you want?`echo $'\n    > 1.Vulkan dev: 455.50.03\n      2.460 series: 460.39\n      3.455 series: 455.45.01\n      4.450 series: 450.102.04\n      5.440 series: 440.100 (kernel 5.8 or lower)\n      6.435 series: 435.21  (kernel 5.6 or lower)\n      7.430 series: 430.64  (kernel 5.5 or lower)\n      8.418 series: 418.113 (kernel 5.5 or lower)\n      9.415 series: 415.27  (kernel 5.4 or lower)\n      10.410 series: 410.104 (kernel 5.5 or lower)\n      11.396 series: 396.54  (kernel 5.3 or lower, 5.1 or lower recommended)\n      12.Custom version (396.xx series or higher)\n    choice[1-12?]: '`" CONDITION;
+  fi
+    # This will be treated as the latest regular driver.
     if [ "$CONDITION" = "2" ]; then
       echo '_driver_version=460.39' > options
       echo '_md5sum=79365687506ff548f9504e9fe0e0bc03' >> options
@@ -89,6 +103,7 @@ if [ -z "$_driver_version" ] || [ -z "$_driver_branch" ] && [ ! -e options ]; th
       fi
       echo "_md5sum='SKIP'" >> options
       echo "_driver_version=$_driver_version" >> options
+    # This (condition 1) will be treated as the latest Vulkan developer driver.
     else
       echo '_driver_version=455.50.03' > options
       echo '_md5sum=2c3905c86da4f2f95059d11284ad690c' >> options
@@ -110,6 +125,8 @@ fi
 if [ -e options ]; then
   source options
 fi
+
+msg2 "Building driver version $_driver_version on branch $_driver_branch."
 
 # Skip header check for dkms-only builds with explicit target kernel version
 if [ "$_dkms" != "true" ] || [ -z "$_kerneloverride" ]; then

--- a/customization.cfg
+++ b/customization.cfg
@@ -28,6 +28,7 @@ _eglwayland="true"
 _driver_branch=""
 
 # Desired driver version - !! needs to be available from the selected branch above !!
+# Set to "latest" to use the latest driver on the selected branch.
 _driver_version=""
 
 # Set to "true" to use DKMS or "false" to use regular modules. You can also use "full" to build both dkms and regular packages (don't use it if you don't know you need it!).


### PR DESCRIPTION
This PR is a proposed fix for #19. This allows one to set the `customization.cfg` variable `$_driver_version` to `latest`, and this will select the latest driver. My use case for this is that I follow the Git log whenever there are new changes, but it's hard to tell which versions are the ones that I want, and it would overall be easier to set-and-forget "latest" :frog: 

This implementation leverages the fact that the list of drivers in the package selector is in order. For the latest regular driver, we just take the first one. For the latest Vulkan beta driver, we take the only one.

A possible consideration: for the [regular branch](https://www.nvidia.com/en-us/drivers/unix/), I see that there is both a *Latest Production Branch Version* and a *Latest New Feature Branch Version*. This PR does not differentiate between the two, e.g. with a `latest-production` and `latest-feature` branch. I am open to implementing this, I just haven't done so because this would put the onus on the maintainer (@Tk-Glitch) to maintain this feature going forward, as opposed to the current state in which just taking the very first driver is unlikely to need any future corrections.