### PR TITLE
Fixed cleanup when using "only update if newer"

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -48,7 +48,7 @@ if [ -z "$_driver_version" ] || [ "$_driver_version" = "latest" ] || [ -z "$_dri
     fi
   fi
   if [[ -z $CONDITION ]]; then
-    read -p "    What driver version do you want?`echo $'\n    > 1.Vulkan dev: 455.50.04\n      2.460 series: 460.39\n      3.455 series: 455.45.01\n      4.450 series: 450.102.04\n      5.440 series: 440.100 (kernel 5.8 or lower)\n      6.435 series: 435.21  (kernel 5.6 or lower)\n      7.430 series: 430.64  (kernel 5.5 or lower)\n      8.418 series: 418.113 (kernel 5.5 or lower)\n      9.415 series: 415.27  (kernel 5.4 or lower)\n      10.410 series: 410.104 (kernel 5.5 or lower)\n      11.396 series: 396.54  (kernel 5.3 or lower, 5.1 or lower recommended)\n      12.Custom version (396.xx series or higher)\n    choice[1-12?]: '`" CONDITION;
+    read -p "    What driver version do you want?`echo $'\n    > 1.Vulkan dev: 455.50.05\n      2.460 series: 460.39\n      3.455 series: 455.45.01\n      4.450 series: 450.102.04\n      5.440 series: 440.100 (kernel 5.8 or lower)\n      6.435 series: 435.21  (kernel 5.6 or lower)\n      7.430 series: 430.64  (kernel 5.5 or lower)\n      8.418 series: 418.113 (kernel 5.5 or lower)\n      9.415 series: 415.27  (kernel 5.4 or lower)\n      10.410 series: 410.104 (kernel 5.5 or lower)\n      11.396 series: 396.54  (kernel 5.3 or lower, 5.1 or lower recommended)\n      12.Custom version (396.xx series or higher)\n    choice[1-12?]: '`" CONDITION;
   fi
     # This will be treated as the latest regular driver.
     if [ "$CONDITION" = "2" ]; then
@@ -105,8 +105,8 @@ if [ -z "$_driver_version" ] || [ "$_driver_version" = "latest" ] || [ -z "$_dri
       echo "_driver_version=$_driver_version" >> options
     # This (condition 1) will be treated as the latest Vulkan developer driver.
     else
-      echo '_driver_version=455.50.04' > options
-      echo '_md5sum=70028ac4061ea0adb3be88f7f19858c4' >> options
+      echo '_driver_version=455.50.05' > options
+      echo '_md5sum=ccda501600bb901ea3261d545432d4ca' >> options
       echo '_driver_branch=vulkandev' >> options
     fi
 # Package type selector
@@ -179,7 +179,7 @@ fi
 
 pkgname=("${_pkgname_array[@]}")
 pkgver=$_driver_version
-pkgrel=150
+pkgrel=151
 arch=('x86_64')
 url="http://www.nvidia.com/"
 license=('custom:NVIDIA')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -152,7 +152,10 @@ if [[ "$_only_update_if_newer" == "true" ]]; then
         plain "If this is not intended, have a look at '"$where"/customization.cfg'"
       fi
 
-      # We shouldn't have done anything yet, so no cleanup needed?
+      # We have to clean up "options"
+      rm -f "${where}"/options
+      # TODO Do we need to clean up something more?
+      # TODO Should the exit_cleanup be called? (requires reorganization of script)
       exit 0
     fi
   else

--- a/customization.cfg
+++ b/customization.cfg
@@ -31,6 +31,11 @@ _driver_branch=""
 # Set to "latest" to use the latest driver on the selected branch.
 _driver_version=""
 
+# Only updates if there is a newer version available
+# Semi-hack, compares version-strings as strings, i.e. if "460.39" > "455.45.01" update etc
+# Set to "true" to enable
+_only_update_if_newer=""
+
 # Set to "true" to use DKMS or "false" to use regular modules. You can also use "full" to build both dkms and regular packages (don't use it if you don't know you need it!).
 _dkms=""
 


### PR DESCRIPTION
Since cleanup was never called the version number in "options" was never properly updated. This should fix that.

@Tk-Glitch Or should I rather reorganize so the `TRAP` and `exit_cleanup` are defined at the start of the script so `exit_cleanup` is called instead?