### PR TITLE
Install `nvidia-ngx-updater` on driver versions ≥ 455

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1101,7 +1101,7 @@ nvidia-utils-tkg() {
     else
       install -D -m755 "libnvidia-ngx.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-ngx.so.${pkgver}"
     fi
-    if [[ $pkgver = 455* ]]; then
+    if (( ${pkgver%%.*} >= 455 )); then
       install -D -m755 nvidia-ngx-updater "${pkgdir}/usr/bin/nvidia-ngx-updater"
     fi
 


### PR DESCRIPTION
It's also present on 460 branch, so let's assume it's there to stay.