### PR TITLE
Add initial kernel 5.14 patch

### DIFF
--- a/patches/kernel-5.14.patch
+++ b/patches/kernel-5.14.patch
@@ -1,0 +1,63 @@
+From f18c541edc5e122b06b0c1e65d0a422f0b8109e7 Mon Sep 17 00:00:00 2001
+From: Joan Bruguera <joanbrugueram@gmail.com>
+Date: Fri, 2 Jul 2021 02:09:58 +0200
+Subject: [PATCH] Tentative fix for NVIDIA 465.31 driver for Linux 5.14-rc1
+
+---
+ common/inc/nv-time.h        | 6 ++++++
+ nvidia-drm/nvidia-drm-drv.c | 4 ++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/kernel-dkms/common/inc/nv-time.h b/kernel-dkms/common/inc/nv-time.h
+index dc80806..cc343a5 100644
+--- a/kernel-dkms/common/inc/nv-time.h
++++ b/kernel-dkms/common/inc/nv-time.h
+@@ -23,6 +23,7 @@
+ #ifndef __NV_TIME_H__
+ #define __NV_TIME_H__
+ 
++#include <linux/version.h>
+ #include "conftest.h"
+ #include <linux/sched.h>
+ #include <linux/delay.h>
+@@ -205,7 +206,12 @@ static inline NV_STATUS nv_sleep_ms(unsigned int ms)
+         // the requested timeout has expired, loop until less
+         // than a jiffie of the desired delay remains.
+         //
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0))
+         current->state = TASK_INTERRUPTIBLE;
++#else
++        // Rel. commit "sched: Change task_struct::state" (Peter Zijlstra, Jun 11 2021)
++        WRITE_ONCE(current->__state, TASK_INTERRUPTIBLE);
++#endif
+         do
+         {
+             schedule_timeout(jiffies);
+diff --git a/kernel-dkms/nvidia-drm/nvidia-drm-drv.c b/kernel-dkms/nvidia-drm/nvidia-drm-drv.c
+index 84d4479..99ea552 100644
+--- a/kernel-dkms/nvidia-drm/nvidia-drm-drv.c
++++ b/kernel-dkms/nvidia-drm/nvidia-drm-drv.c
+@@ -20,6 +20,7 @@
+  * DEALINGS IN THE SOFTWARE.
+  */
+ 
++#include <linux/version.h>
+ #include "nvidia-drm-conftest.h" /* NV_DRM_AVAILABLE and NV_DRM_DRM_GEM_H_PRESENT */
+ 
+ #include "nvidia-drm-priv.h"
+@@ -903,9 +904,12 @@ static void nv_drm_register_drm_device(const nv_gpu_info_t *gpu_info)
+ 
+     dev->dev_private = nv_dev;
+     nv_dev->dev = dev;
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0))
++    // Rel. commit "drm: Remove pdev field from struct drm_device" (Thomas Zimmermann, 3 May 2021)
+     if (device->bus == &pci_bus_type) {
+         dev->pdev = to_pci_dev(device);
+     }
++#endif
+ 
+     /* Register DRM device to DRM sub-system */
+ 
+-- 
+2.32.0
+


### PR DESCRIPTION
Credits for the patch go to Joan Bruguera
https://gist.github.com/joanbm/144a965c36fc1dc0d1f1b9be3438a368
Enabled for 465 and 470 branch
Tested on 5.14rc3 + 470.57.02

Edit: this commit also removes the the pahole makedep, that was incorrectly suspected during kernel 5.11 but when it turned out to be headers dep, it was still kept as plenty other custom kernels didn't include it, but i think enough time passed that it can be safely removed. 