### PR TITLE
Updating the nvidia-settings icon path (again)

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1302,7 +1302,7 @@ nvidia-settings-tkg() {
     install -D -m644 nvidia-settings.1.gz    -t "${pkgdir}/usr/share/man/man1"
     install -D -m644 nvidia-settings.png     -t "${pkgdir}/usr/share/pixmaps"
     install -D -m644 nvidia-settings.desktop -t "${pkgdir}/usr/share/applications"
-    sed -e 's:__UTILS_PATH__:/usr/bin:' -e 's:__PIXMAP_PATH__:/usr/share/pixmaps:' -i "${pkgdir}/usr/share/applications/nvidia-settings.desktop"
+    sed -e 's:__UTILS_PATH__:/usr/bin:' -e 's:__PIXMAP_PATH__/nvidia-settings.png:nvidia-settings:' -i "${pkgdir}/usr/share/applications/nvidia-settings.desktop"
 
     install -D -m755 "libnvidia-gtk3.so.${pkgver}" -t "${pkgdir}/usr/lib"
 


### PR DESCRIPTION
Updating the icon again. Last time was a mistake, I apologize. [I wrote about it](https://github.com/Frogging-Family/nvidia-all/issues/58#issuecomment-899084631) in the related issue caused by my erroneous commit, but apparently it wasn't noticed so I created the PR again.

Recall that this change is already present in Ubuntu, Fedora (RPM Fusion) and Gentoo distributions, but so far not considered in [Arch Linux](https://bugs.archlinux.org/task/54495?project=1&string=nvidia-settings).

Fixes: https://github.com/Frogging-Family/nvidia-all/issues/58