### PR TITLE
Adding a workaround for building kernel modules via LLVM/Clang

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1029,7 +1029,7 @@ build() {
       # Build module
       msg2 "Building Nvidia module for $_kernel..."
 
-      if [[ $_force_clang_usage = "true" ]]; then
+      if [[ $_force_clang_usage = "true" ]] && [[ ! -z $(strings /usr/lib/modules/$_kernel/vmlinuz | grep llvm) ]]; then
         export CC=clang CXX=clang++ LD=ld.lld AS=llvm-as AR=llvm-ar NM=llvm-nm OBJCOPY=llvm-objcopy OBJSIZE=llvm-size STRIP=llvm-strip
       fi
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -231,6 +231,11 @@ arch=('x86_64')
 url="http://www.nvidia.com/"
 license=('custom:NVIDIA')
 optdepends=('linux-headers' 'linux-lts-headers: Build the module for LTS Arch kernel')
+
+if [[ $_force_clang_usage = "true" ]]; then
+  depends=('llvm' 'clang' 'lld')
+fi
+
 options=('!strip')
 
 cp "$where"/patches/* "$where" && cp -r "$where"/system/* "$where"
@@ -1023,6 +1028,11 @@ build() {
 
       # Build module
       msg2 "Building Nvidia module for $_kernel..."
+
+      if [[ $_force_clang_usage = "true" ]]; then
+        export CC=clang CXX=clang++ LD=ld.lld AS=llvm-as AR=llvm-ar NM=llvm-nm OBJCOPY=llvm-objcopy OBJSIZE=llvm-size STRIP=llvm-strip
+      fi
+
       make SYSSRC=/usr/lib/modules/$_kernel/build modules
     done
   fi
@@ -1460,10 +1470,6 @@ if [ "$_dkms" = "true" ] || [ "$_dkms" = "full" ]; then
     depends=('dkms' "nvidia-utils-tkg>=${pkgver}" 'nvidia-libgl' 'pahole')
     provides=("nvidia=${pkgver}" 'nvidia-dkms' "nvidia-dkms-tkg=${pkgver}" 'NVIDIA-MODULE')
     conflicts=('nvidia' 'nvidia-dkms')
-
-    if [[ $_force_clang_usage = "true" ]]; then
-      depends+=('llvm' 'clang' 'lld')
-    fi
 
     cd ${_pkg}
     install -dm 755 "${pkgdir}"/usr/{lib/modprobe.d,src}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -375,6 +375,12 @@ prepare() {
 
   cp -a kernel kernel-dkms
   cd kernel-dkms
+
+  # workaround for dkms+clang
+  if [[ $_force_clang_usage = "true" ]]; then
+    sed -i "s/'make'/'make' CC=clang CXX=clang++ LD=ld.lld AS=llvm-as AR=llvm-ar NM=llvm-nm OBJCOPY=llvm-objcopy OBJSIZE=llvm-size STRIP=llvm-strip/" dkms.conf
+  fi
+
   sed -i "s/__VERSION_STRING/${pkgver}/" dkms.conf
   sed -i 's/__JOBS/`nproc`/' dkms.conf
   sed -i 's/__DKMS_MODULES//' dkms.conf
@@ -1454,6 +1460,10 @@ if [ "$_dkms" = "true" ] || [ "$_dkms" = "full" ]; then
     depends=('dkms' "nvidia-utils-tkg>=${pkgver}" 'nvidia-libgl' 'pahole')
     provides=("nvidia=${pkgver}" 'nvidia-dkms' "nvidia-dkms-tkg=${pkgver}" 'NVIDIA-MODULE')
     conflicts=('nvidia' 'nvidia-dkms')
+
+    if [[ $_force_clang_usage = "true" ]]; then
+      depends+=('llvm' 'clang' 'lld')
+    fi
 
     cd ${_pkg}
     install -dm 755 "${pkgdir}"/usr/{lib/modprobe.d,src}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -236,7 +236,7 @@ url="http://www.nvidia.com/"
 license=('custom:NVIDIA')
 optdepends=('linux-headers' 'linux-lts-headers: Build the module for LTS Arch kernel')
 
-if [[ $_force_clang_usage = "true" ]]; then
+if [[ $_compiler = "llvm" ]]; then
   depends=('llvm' 'clang' 'lld')
 fi
 
@@ -388,7 +388,7 @@ prepare() {
   sed -i "s/__VERSION_STRING/${pkgver}/" dkms.conf
   sed -i 's/__JOBS/`nproc`/' dkms.conf
 
-  if [[ $_force_clang_usage = "true" ]]; then
+  if [[ $_compiler = "llvm" ]]; then
     sed -i '1s/^/if [[ ! -z $(strings $kernel_source_dir\/vmlinux 2>\/dev\/null | grep llvm) ]]; then\n  LLVM_UTILS="CC=clang CXX=clang++ LD=ld.lld AS=llvm-as AR=llvm-ar NM=llvm-nm OBJCOPY=llvm-objcopy OBJSIZE=llvm-size STRIP=llvm-strip" \nfi\n\n/' dkms.conf
     sed -i 's/-j`nproc`/${LLVM_UTILS} -j`nproc`/' dkms.conf
   fi
@@ -1034,7 +1034,7 @@ build() {
       # Build module
       msg2 "Building Nvidia module for $_kernel..."
 
-      if [[ $_force_clang_usage = "true" ]] && [[ ! -z $(strings /usr/lib/modules/$_kernel/build/vmlinux | grep llvm) ]]; then
+      if [[ $_compiler = "llvm" ]] && [[ ! -z $(strings /usr/lib/modules/$_kernel/build/vmlinux | grep llvm) ]]; then
         export IGNORE_CC_MISMATCH=1 CC=clang CXX=clang++ LD=ld.lld AS=llvm-as AR=llvm-ar NM=llvm-nm OBJCOPY=llvm-objcopy OBJSIZE=llvm-size STRIP=llvm-strip
       fi
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -360,7 +360,9 @@ prepare() {
   [ -d "$_pkg" ] && rm -rf "$_pkg"
 
   # Use custom compiler paths if defined
-  if [ -n "${CUSTOM_GCC_PATH}" ]; then
+  if [ "$_compiler" = "llvm" ] && [ -n "${CUSTOM_LLVM_PATH}" ]; then
+    PATH=${CUSTOM_LLVM_PATH}/bin:${CUSTOM_LLVM_PATH}/lib:${CUSTOM_LLVM_PATH}/include:${PATH}
+  elif [ -n "${CUSTOM_GCC_PATH}" ]; then
     PATH=${CUSTOM_GCC_PATH}/bin:${CUSTOM_GCC_PATH}/lib:${CUSTOM_GCC_PATH}/include:${PATH}
   fi
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1030,7 +1030,7 @@ build() {
       msg2 "Building Nvidia module for $_kernel..."
 
       if [[ $_force_clang_usage = "true" ]] && [[ ! -z $(strings /usr/lib/modules/$_kernel/vmlinuz | grep llvm) ]]; then
-        export CC=clang CXX=clang++ LD=ld.lld AS=llvm-as AR=llvm-ar NM=llvm-nm OBJCOPY=llvm-objcopy OBJSIZE=llvm-size STRIP=llvm-strip
+        export IGNORE_CC_MISMATCH=1 CC=clang CXX=clang++ LD=ld.lld AS=llvm-as AR=llvm-ar NM=llvm-nm OBJCOPY=llvm-objcopy OBJSIZE=llvm-size STRIP=llvm-strip
       fi
 
       make SYSSRC=/usr/lib/modules/$_kernel/build modules

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1033,7 +1033,7 @@ build() {
       # Build module
       msg2 "Building Nvidia module for $_kernel..."
 
-      if [[ $_force_clang_usage = "true" ]] && [[ ! -z $(strings /usr/lib/modules/$_kernel/vmlinuz | grep llvm) ]]; then
+      if [[ $_force_clang_usage = "true" ]] && [[ ! -z $(strings /usr/lib/modules/$_kernel/build/vmlinux | grep llvm) ]]; then
         export IGNORE_CC_MISMATCH=1 CC=clang CXX=clang++ LD=ld.lld AS=llvm-as AR=llvm-ar NM=llvm-nm OBJCOPY=llvm-objcopy OBJSIZE=llvm-size STRIP=llvm-strip
       fi
 

--- a/customization.cfg
+++ b/customization.cfg
@@ -11,6 +11,11 @@ _EXT_CONFIG_PATH=~/.config/frogminer/nvidia-all.cfg
 # Example: CUSTOM_GCC_PATH="/home/frog/PKGBUILDS/mostlyportable-gcc/gcc-mostlyportable-9.2.0"
 CUSTOM_GCC_PATH=""
 
+# Custom compiler root dirs - For non-dkms builds (see readme to use this with dkms) - Leave empty to use system compilers
+# ! If your kernel was built with mostlyportable LLVM, you need to use the exact same build here or module compilation will fail !
+# Example: CUSTOM_LLVM_PATH="/home/frog/PKGBUILDS/mostlyportable-llvm/llvm-mostlyportable-11.0.0"
+CUSTOM_LLVM_PATH=""
+
 # Allows enforcing kernel patches application for a target kernel, independently of currently installed ones (example: "5.5")
 # You typically don't want to use this as a user. The proper way it to install your kernel(s), then run makepkg against nvidia-all's PKGBUILD to get things autodetected.
 _kerneloverride=""

--- a/customization.cfg
+++ b/customization.cfg
@@ -15,8 +15,8 @@ CUSTOM_GCC_PATH=""
 # You typically don't want to use this as a user. The proper way it to install your kernel(s), then run makepkg against nvidia-all's PKGBUILD to get things autodetected.
 _kerneloverride=""
 
-# Forced use of the clang compiler to build DKMS modules
-# Works only for kernels built by clang and if the _dkms option is enabled
+# Forced use of the clang compiler to build kernel modules
+# Works only for kernels built by LLVM/Clang
 # Note: This is experimental and not officially supported by driver/DKMS.
 # Please do not send bug reports to NVIDIA with this option enabled.
 _force_clang_usage=""

--- a/customization.cfg
+++ b/customization.cfg
@@ -15,6 +15,12 @@ CUSTOM_GCC_PATH=""
 # You typically don't want to use this as a user. The proper way it to install your kernel(s), then run makepkg against nvidia-all's PKGBUILD to get things autodetected.
 _kerneloverride=""
 
+# Forced use of the clang compiler to build DKMS modules
+# Works only for kernels built by clang and if the _dkms option is enabled
+# Note: This is experimental and not officially supported by driver/DKMS.
+# Please do not send bug reports to NVIDIA with this option enabled.
+_force_clang_usage=""
+
 # Put the built packages in a versioned dir in the same folder as the nvidia-all PKGBUILD on exit - Will fail to install if running makepkg with -i option
 _local_package_storing="false"
 

--- a/customization.cfg
+++ b/customization.cfg
@@ -19,7 +19,7 @@ _kerneloverride=""
 # Works only for kernels built by LLVM/Clang
 # Note: This is experimental and not officially supported by driver/DKMS.
 # Please do not send bug reports to NVIDIA with this option enabled.
-_force_clang_usage=""
+_force_clang_usage="true"
 
 # Put the built packages in a versioned dir in the same folder as the nvidia-all PKGBUILD on exit - Will fail to install if running makepkg with -i option
 _local_package_storing="false"

--- a/customization.cfg
+++ b/customization.cfg
@@ -15,11 +15,12 @@ CUSTOM_GCC_PATH=""
 # You typically don't want to use this as a user. The proper way it to install your kernel(s), then run makepkg against nvidia-all's PKGBUILD to get things autodetected.
 _kerneloverride=""
 
-# Forced use of the clang compiler to build kernel modules
-# Works only for kernels built by LLVM/Clang
+# Compiler to use - Options are "gcc" or "llvm".
+# For advanced users.
+# The LLVM compiler is used only for kernels built with it.
 # Note: This is experimental and not officially supported by driver/DKMS.
 # Please do not send bug reports to NVIDIA with this option enabled.
-_force_clang_usage="true"
+_compiler=""
 
 # Put the built packages in a versioned dir in the same folder as the nvidia-all PKGBUILD on exit - Will fail to install if running makepkg with -i option
 _local_package_storing="false"


### PR DESCRIPTION
Adds a workaround for building modules via clang. Works by forcing environment variables in `dkms.conf`. This works fine for me and linux-tkg-llvm, but it's not a perfect solution, and I understand that it could break at every step if NVIDIA changes something.

So I'm not sure what it should be in the upstream, but still decided to leave it here.

Closes: https://github.com/Frogging-Family/nvidia-all/issues/55 https://github.com/Frogging-Family/nvidia-all/issues/36