### PR TITLE
vulkan beta driver 470.62.13

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -48,7 +48,7 @@ if [ -z "$_driver_version" ] || [ "$_driver_version" = "latest" ] || [ -z "$_dri
     fi
   fi
   if [[ -z $CONDITION ]]; then
-    read -p "    What driver version do you want?`echo $'\n    > 1.Vulkan dev: 470.62.12\n      2.495 series: 495.44\n      3.470 series: 470.86\n      4.465 series: 465.31\n      5.460 series: 460.91.03\n      6.455 series: 455.45.01\n      7.450 series: 450.119.03\n      8.440 series: 440.100 (kernel 5.8 or lower)\n      9.435 series: 435.21  (kernel 5.6 or lower)\n      10.430 series: 430.64  (kernel 5.5 or lower)\n      11.418 series: 418.113 (kernel 5.5 or lower)\n      12.415 series: 415.27  (kernel 5.4 or lower)\n      13.410 series: 410.104 (kernel 5.5 or lower)\n      14.396 series: 396.54  (kernel 5.3 or lower, 5.1 or lower recommended)\n      15.Custom version (396.xx series or higher)\n    choice[1-15?]: '`" CONDITION;
+    read -p "    What driver version do you want?`echo $'\n    > 1.Vulkan dev: 470.62.13\n      2.495 series: 495.44\n      3.470 series: 470.86\n      4.465 series: 465.31\n      5.460 series: 460.91.03\n      6.455 series: 455.45.01\n      7.450 series: 450.119.03\n      8.440 series: 440.100 (kernel 5.8 or lower)\n      9.435 series: 435.21  (kernel 5.6 or lower)\n      10.430 series: 430.64  (kernel 5.5 or lower)\n      11.418 series: 418.113 (kernel 5.5 or lower)\n      12.415 series: 415.27  (kernel 5.4 or lower)\n      13.410 series: 410.104 (kernel 5.5 or lower)\n      14.396 series: 396.54  (kernel 5.3 or lower, 5.1 or lower recommended)\n      15.Custom version (396.xx series or higher)\n    choice[1-15?]: '`" CONDITION;
   fi
     # This will be treated as the latest regular driver.
     if [ "$CONDITION" = "2" ]; then
@@ -117,8 +117,8 @@ if [ -z "$_driver_version" ] || [ "$_driver_version" = "latest" ] || [ -z "$_dri
       echo "_driver_version=$_driver_version" >> options
     # This (condition 1) will be treated as the latest Vulkan developer driver.
     else
-      echo '_driver_version=470.62.12' > options
-      echo '_md5sum=7967b275d038b7b039f9d8a7abda1bac' >> options
+      echo '_driver_version=470.62.13' > options
+      echo '_md5sum=e9722ae8766fc63f4211ed3d70c3a280' >> options
       echo '_driver_branch=vulkandev' >> options
     fi
 # Package type selector
@@ -230,7 +230,7 @@ fi
 
 pkgname=("${_pkgname_array[@]}")
 pkgver=$_driver_version
-pkgrel=187
+pkgrel=188
 arch=('x86_64')
 url="http://www.nvidia.com/"
 license=('custom:NVIDIA')


### PR DESCRIPTION
```
November 24th, 2021 - Windows 472.77, Linux 470.62.13

    New:
        VK_EXT_depth_clip_control
    Fixes:
        Fixed some unset VkVideoDecodeH264CapabilitiesEXT query fields
        Fixed VK_TIME_DOMAIN_DEVICE_EXT query on SLI platforms
```