### PR TITLE
470.x: backport acpi changes from 515.x [1]

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -334,6 +334,7 @@ source=($_source_name
         'kernel-5.16-std.diff' # 5.16 workaround for 470.6x
         'kernel-5.17.patch' # 5.17 workaround
         'kernel-6.0.patch'
+        'kernel-6.0-470.patch' # acpi backports from 515.x for 470.x
 )
 
 msg2 "Selected driver integrity check behavior (md5sum or SKIP): $_md5sum" # If the driver is "known", return md5sum. If it isn't, return SKIP
@@ -375,7 +376,8 @@ md5sums=("$_md5sum"
          'd684ca11fdc9894c14ead69cb35a5946'
          '0f987607c98eb6faeb7d691213de6a70'
          'a70bc9cbbc7e8563b48985864a11de71'
-         '31128900574dec9ebdb753db50ef4f16')
+         '31128900574dec9ebdb753db50ef4f16'
+         '0b9b855d9be313153a5903e46e774a30')
 
 if [ "$_open_source_modules" = "true" ]; then
   source+=("$pkgname-$pkgver.tar.gz::https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/${pkgver}.tar.gz")
@@ -764,7 +766,7 @@ DEST_MODULE_LOCATION[3]="/kernel/drivers/video"' dkms.conf
       # 6.0
       if (( $(vercmp "$_kernel" "6.0") >= 0 )); then
         _kernel60="1"
-        _whitelist60=( 515.6* )
+        _whitelist60=( 515.6* 470.* )
       fi
 
       # Loop patches (linux-4.15.patch, lol.patch, ...)
@@ -1173,6 +1175,10 @@ DEST_MODULE_LOCATION[3]="/kernel/drivers/video"' dkms.conf
           [[ $pkgver = $yup ]] && patchy=1
         done
         if [ "$patchy" = "1" ]; then
+          if [[ "$yup" =~ ^470\..* ]]; then
+            msg2 "Applying kernel-6.0-470.patch for dkms ..."
+            patch -Np1 -i "$srcdir"/kernel-6.0-470.patch
+          fi
           msg2 "Applying kernel-6.0.patch for dkms..."
           patch -Np1 -i "$srcdir"/kernel-6.0.patch
         else

--- a/patches/kernel-6.0-470.patch
+++ b/patches/kernel-6.0-470.patch
@@ -1,0 +1,900 @@
+From 060c1b23e09e25484b5560d18384a92b91510baf Mon Sep 17 00:00:00 2001
+From: Jebaitedneko <Jebaitedneko@gmail.com>
+Date: Sat, 8 Oct 2022 16:54:52 +0530
+Subject: [PATCH 1/4] Backport acpi changes from 515.x [1] for lnx-6.x
+
+[1] https://github.com/NVIDIA/open-gpu-kernel-modules
+---
+ kernel-dkms/common/inc/nv-linux.h   |  12 -
+ kernel-dkms/common/inc/nv-proto.h   |   2 -
+ kernel-dkms/conftest.sh             |  72 +--
+ kernel-dkms/nvidia/nv-acpi.c        | 508 +-----------------
+ kernel-dkms/nvidia/nv.c             |  28 +-
+ kernel-dkms/nvidia/nvidia.Kbuild    |   3 +-
+ 6 files changed, 47 insertions(+), 578 deletions(-)
+
+diff --git a/kernel-dkms/common/inc/nv-linux.h b/kernel-dkms/common/inc/nv-linux.h
+index 51a973b..22b05a0 100644
+--- a/kernel-dkms/common/inc/nv-linux.h
++++ b/kernel-dkms/common/inc/nv-linux.h
+@@ -1627,24 +1627,12 @@ extern NvBool nv_ats_supported;
+  * and any other baggage we want to carry along
+  *
+  */
+-#define NV_MAXNUM_DISPLAY_DEVICES 8
+-
+-typedef struct
+-{
+-    acpi_handle dev_handle;
+-    int dev_id;
+-} nv_video_t;
+-
+ typedef struct
+ {
+     nvidia_stack_t *sp;
+     struct acpi_device *device;
+     struct acpi_handle *handle;
+-
+-    nv_video_t pNvVideo[NV_MAXNUM_DISPLAY_DEVICES];
+-
+     int notify_handler_installed;
+-    int default_display_mask;
+ } nv_acpi_t;
+ 
+ #endif
+diff --git a/kernel-dkms/common/inc/nv-proto.h b/kernel-dkms/common/inc/nv-proto.h
+index 79cccfa..aa8b285 100644
+--- a/kernel-dkms/common/inc/nv-proto.h
++++ b/kernel-dkms/common/inc/nv-proto.h
+@@ -22,8 +22,6 @@ extern nvidia_module_t nv_fops;
+ 
+ void        nv_acpi_register_notifier   (nv_linux_state_t *);
+ void        nv_acpi_unregister_notifier (nv_linux_state_t *);
+-int         nv_acpi_init                (void);
+-int         nv_acpi_uninit              (void);
+ 
+ NvU8        nv_find_pci_capability      (struct pci_dev *, NvU8);
+ void *      nv_alloc_file_private       (void);
+diff --git a/kernel-dkms/conftest.sh b/kernel-dkms/conftest.sh
+index 04997fb..9a4ae6d 100755
+--- a/kernel-dkms/conftest.sh
++++ b/kernel-dkms/conftest.sh
+@@ -703,45 +703,6 @@ compile_test() {
+             compile_check_conftest "$CODE" "NV_HASH__REMAP_4K_PFN_PRESENT" "" "functions"
+         ;;
+ 
+-        acpi_op_remove)
+-            #
+-            # Determine the number of arguments to pass to the
+-            # 'acpi_op_remove' routine.
+-            #
+-            # Second parameter removed by commit 51fac8388a03
+-            # ("ACPI: Remove useless type argument of driver .remove()
+-            # operation") in v3.9
+-            #
+-            echo "$CONFTEST_PREAMBLE
+-            #include <linux/acpi.h>
+-
+-            acpi_op_remove conftest_op_remove_routine;
+-
+-            int conftest_acpi_device_ops_remove(struct acpi_device *device) {
+-                return conftest_op_remove_routine(device);
+-            }" > conftest$$.c
+-
+-            $CC $CFLAGS -c conftest$$.c > /dev/null 2>&1
+-            rm -f conftest$$.c
+-
+-            if [ -f conftest$$.o ]; then
+-                rm -f conftest$$.o
+-                echo "#define NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT 1" | append_conftest "types"
+-                return
+-            fi
+-
+-            CODE="
+-            #include <linux/acpi.h>
+-
+-            acpi_op_remove conftest_op_remove_routine;
+-
+-            int conftest_acpi_device_ops_remove(struct acpi_device *device, int type) {
+-                return conftest_op_remove_routine(device, type);
+-            }"
+-
+-            compile_check_conftest "$CODE" "NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT" "2" "types"
+-        ;;
+-
+         acquire_console_sem)
+             #
+             # Determine if the acquire_console_sem() function
+@@ -4738,22 +4699,6 @@ compile_test() {
+             compile_check_conftest "$CODE" "NV_DMA_SET_COHERENT_MASK_PRESENT" "" "functions"
+         ;;
+ 
+-        acpi_bus_get_device)
+-            #
+-            # Determine if the acpi_bus_get_device() function is present
+-            #
+-            # acpi_bus_get_device() was removed by commit ac2a3feefad5
+-            # ("ACPI: bus: Eliminate acpi_bus_get_device()") in
+-            # v5.18-rc2 (2022-04-05).
+-            #
+-            CODE="
+-            #include <linux/acpi.h>
+-            int conftest_acpi_bus_get_device(void) {
+-                return acpi_bus_get_device();
+-            }"
+-            compile_check_conftest "$CODE" "NV_ACPI_BUS_GET_DEVICE_PRESENT" "" "functions"
+-        ;;
+-
+         dma_resv_add_fence)
+             #
+             # Determine if the dma_resv_add_fence() function is present.
+@@ -4815,6 +4760,23 @@ compile_test() {
+             compile_check_conftest "$CODE" "NV_RESERVATION_OBJECT_RESERVE_SHARED_HAS_NUM_FENCES_ARG" "" "types"
+         ;;
+ 
++        get_task_ioprio)
++            #
++            # Determine if the __get_task_ioprio() function is present.
++            #
++            # __get_task_ioprio was added by commit 893e5d32d583
++            # ("block: Generalize get_current_ioprio() for any task") for
++            # v5.20 linux-next (2022-06-23).
++            #
++            CODE="
++            #include <linux/ioprio.h>
++            void conftest_get_task_ioprio(void) {
++                __get_task_ioprio();
++            }"
++
++            compile_check_conftest "$CODE" "NV_GET_TASK_IOPRIO_PRESENT" "" "functions"
++        ;;
++
+         # When adding a new conftest entry, please use the correct format for
+         # specifying the relevant upstream Linux kernel commit.
+         #
+diff --git a/kernel-dkms/nvidia/nv-acpi.c b/kernel-dkms/nvidia/nv-acpi.c
+index 2b7b988..4ec227c 100644
+--- a/kernel-dkms/nvidia/nv-acpi.c
++++ b/kernel-dkms/nvidia/nv-acpi.c
+@@ -22,35 +22,13 @@ static NV_STATUS   nv_acpi_extract_buffer  (const union acpi_object *, void *, N
+ static NV_STATUS   nv_acpi_extract_package (const union acpi_object *, void *, NvU32, NvU32 *);
+ static NV_STATUS   nv_acpi_extract_object  (const union acpi_object *, void *, NvU32, NvU32 *);
+ 
+-static int         nv_acpi_add             (struct acpi_device *);
+-
+-#if !defined(NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT) || (NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT == 2)
+-static int         nv_acpi_remove_two_args(struct acpi_device *device, int type);
+-#else
+-static int         nv_acpi_remove_one_arg(struct acpi_device *device);
+-#endif
+-
+-static void        nv_acpi_event           (acpi_handle, u32, void *);
+ static void        nv_acpi_powersource_hotplug_event(acpi_handle, u32, void *);
+ static acpi_status nv_acpi_find_methods    (acpi_handle, u32, void *, void **);
+ static NV_STATUS   nv_acpi_nvif_method     (NvU32, NvU32, void *, NvU16, NvU32 *, void *, NvU16 *);
+ 
+ static NV_STATUS   nv_acpi_wmmx_method     (NvU32, NvU8 *, NvU16 *);
+ 
+-static const struct acpi_device_id nv_video_device_ids[] = {
+-    {
+-        .id          = ACPI_VIDEO_HID,
+-        .driver_data = 0,
+-    },
+-    {
+-        .id          = "",
+-        .driver_data = 0,
+-    },
+-};
+-
+-static struct acpi_driver *nv_acpi_driver;
+ static acpi_handle nvif_handle = NULL;
+-static acpi_handle nvif_parent_gpu_handle  = NULL;
+ static acpi_handle wmmx_handle = NULL;
+ 
+ // Used for AC Power Source Hotplug Handling
+@@ -74,20 +52,6 @@ static NvBool battery_present = NV_FALSE;
+ #define ACPI_VIDEO_CLASS    "video"
+ #endif
+ 
+-static const struct acpi_driver nv_acpi_driver_template = {
+-    .name = "NVIDIA ACPI Video Driver",
+-    .class = ACPI_VIDEO_CLASS,
+-    .ids = nv_video_device_ids,
+-    .ops = {
+-        .add = nv_acpi_add,
+-#if !defined(NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT) || (NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT == 2)
+-        .remove = nv_acpi_remove_two_args,
+-#else
+-        .remove = nv_acpi_remove_one_arg,
+-#endif
+-    },
+-};
+-
+ static int nv_acpi_get_device_handle(nv_state_t *nv, acpi_handle *dev_handle)
+ {
+     nv_linux_state_t *nvl = NV_GET_NVL_FROM_NV_STATE(nv);
+@@ -148,355 +112,6 @@ void nv_acpi_unregister_notifier(nv_linux_state_t *nvl)
+     unregister_acpi_notifier(&nvl->acpi_nb);
+ }
+ 
+-int nv_acpi_init(void)
+-{
+-    /*
+-     * This function will register the RM with the Linux
+-     * ACPI subsystem.
+-     */
+-    int status;
+-    nvidia_stack_t *sp = NULL;
+-    NvU32 acpi_event_config = 0;
+-    NV_STATUS rmStatus;
+-
+-    status = nv_kmem_cache_alloc_stack(&sp);
+-    if (status != 0)
+-    {
+-        return status;
+-    }
+-
+-    rmStatus = rm_read_registry_dword(sp, NULL,
+-                   NV_REG_REGISTER_FOR_ACPI_EVENTS, &acpi_event_config);
+-    nv_kmem_cache_free_stack(sp);
+-
+-    if ((rmStatus == NV_OK) && (acpi_event_config == 0))
+-        return 0;
+-
+-    if (nv_acpi_driver != NULL)
+-        return -EBUSY;
+-
+-    rmStatus = os_alloc_mem((void **)&nv_acpi_driver,
+-            sizeof(struct acpi_driver));
+-    if (rmStatus != NV_OK)
+-        return -ENOMEM;
+-
+-    memcpy((void *)nv_acpi_driver, (void *)&nv_acpi_driver_template,
+-            sizeof(struct acpi_driver));
+-
+-    status = acpi_bus_register_driver(nv_acpi_driver);
+-    if (status < 0)
+-    {
+-        nv_printf(NV_DBG_INFO,
+-            "NVRM: nv_acpi_init: acpi_bus_register_driver() failed (%d)!\n", status);
+-        os_free_mem(nv_acpi_driver);
+-        nv_acpi_driver = NULL;
+-    }
+-
+-    return status;
+-}
+-
+-int nv_acpi_uninit(void)
+-{
+-    nvidia_stack_t *sp = NULL;
+-    NvU32 acpi_event_config = 0;
+-    NV_STATUS rmStatus;
+-    int rc;
+-
+-    rc = nv_kmem_cache_alloc_stack(&sp);
+-    if (rc != 0)
+-    {
+-        return rc;
+-    }
+-
+-    rmStatus = rm_read_registry_dword(sp, NULL,
+-                   NV_REG_REGISTER_FOR_ACPI_EVENTS, &acpi_event_config);
+-    nv_kmem_cache_free_stack(sp);
+-
+-    if ((rmStatus == NV_OK) && (acpi_event_config == 0))
+-        return 0;
+-
+-    if (nv_acpi_driver == NULL)
+-        return -ENXIO;
+-
+-    acpi_bus_unregister_driver(nv_acpi_driver);
+-    os_free_mem(nv_acpi_driver);
+-
+-    nv_acpi_driver = NULL;
+-
+-    return 0;
+-}
+-
+-static int nv_acpi_add(struct acpi_device *device)
+-{
+-    /*
+-     * This function will cause RM to initialize the things it needs for acpi interaction
+-     * on the display device.
+-     */
+-    int status = -1;
+-    NV_STATUS rmStatus = NV_ERR_GENERIC;
+-    nv_acpi_t *pNvAcpiObject = NULL;
+-    union acpi_object control_argument_0 = { ACPI_TYPE_INTEGER };
+-    struct acpi_object_list control_argument_list = { 0, NULL };
+-    nvidia_stack_t *sp = NULL;
+-    struct list_head *node, *next;
+-    unsigned long long device_id = 0;
+-    int device_counter = 0;
+-
+-    status = nv_kmem_cache_alloc_stack(&sp);
+-    if (status != 0)
+-    {
+-        return status;
+-    }
+-
+-    // allocate data structure we need
+-    rmStatus = os_alloc_mem((void **) &pNvAcpiObject, sizeof(nv_acpi_t));
+-    if (rmStatus != NV_OK)
+-    {
+-        nv_kmem_cache_free_stack(sp);
+-        nv_printf(NV_DBG_ERRORS,
+-            "NVRM: nv_acpi_add: failed to allocate ACPI device management data!\n");
+-        return -ENOMEM;
+-    }
+-
+-    os_mem_set((void *)pNvAcpiObject, 0, sizeof(nv_acpi_t));
+-
+-    device->driver_data = pNvAcpiObject;
+-    pNvAcpiObject->device = device;
+-
+-    pNvAcpiObject->sp = sp;
+-
+-    // grab handles to all the important nodes representing devices
+-
+-    list_for_each_safe(node, next, &device->children)
+-    {
+-        struct acpi_device *dev =
+-            list_entry(node, struct acpi_device, node);
+-
+-        if (!dev)
+-            continue;
+-
+-        if (device_counter == NV_MAXNUM_DISPLAY_DEVICES)
+-        {
+-            nv_printf(NV_DBG_ERRORS,
+-                      "NVRM: nv_acpi_add: Total number of devices cannot exceed %d\n",
+-                      NV_MAXNUM_DISPLAY_DEVICES);
+-            break;
+-        }
+-
+-        status =
+-            acpi_evaluate_integer(dev->handle, "_ADR", NULL, &device_id);
+-        if (ACPI_FAILURE(status))
+-            /* Couldnt query device_id for this device */
+-            continue;
+-
+-        device_id = (device_id & 0xffff);
+-
+-        if ((device_id != 0x100) && /* Not a known CRT device-id */
+-            (device_id != 0x200) && /* Not a known TV device-id */
+-            (device_id != 0x0110) && (device_id != 0x0118) && (device_id != 0x0400) && /* Not an LCD*/
+-            (device_id != 0x0111) && (device_id != 0x0120) && (device_id != 0x0300)) /* Not a known DVI device-id */
+-        {
+-            /* This isnt a known device Id.
+-               Do default switching on this system. */
+-            pNvAcpiObject->default_display_mask = 1;
+-            break;
+-        }
+-
+-        pNvAcpiObject->pNvVideo[device_counter].dev_id = device_id;
+-        pNvAcpiObject->pNvVideo[device_counter].dev_handle = dev->handle;
+-
+-        device_counter++;
+-
+-    }
+-
+-    // arg 0, bits 1:0, 0 = enable events
+-    control_argument_0.integer.type = ACPI_TYPE_INTEGER;
+-    control_argument_0.integer.value = 0x0;
+-
+-    // listify it
+-    control_argument_list.count = 1;
+-    control_argument_list.pointer = &control_argument_0;
+-
+-    // _DOS method takes 1 argument and returns nothing
+-    status = acpi_evaluate_object(device->handle, "_DOS", &control_argument_list, NULL);
+-
+-    if (ACPI_FAILURE(status))
+-    {
+-        nv_printf(NV_DBG_INFO,
+-            "NVRM: nv_acpi_add: failed to enable display switch events (%d)!\n", status);
+-    }
+-
+-    status = acpi_install_notify_handler(device->handle, ACPI_DEVICE_NOTIFY,
+-                    nv_acpi_event, pNvAcpiObject);
+-
+-    if (ACPI_FAILURE(status))
+-    {
+-        nv_printf(NV_DBG_INFO,
+-            "NVRM: nv_acpi_add: failed to install event notification handler (%d)!\n", status);
+-    }
+-    else
+-    {
+-        try_module_get(THIS_MODULE);
+-        pNvAcpiObject->notify_handler_installed = 1;
+-    }
+-
+-    return 0;
+-}
+-
+-#if !defined(NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT) || (NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT == 2)
+-static int nv_acpi_remove_two_args(struct acpi_device *device, int type)
+-#else
+-static int nv_acpi_remove_one_arg(struct acpi_device *device)
+-#endif
+-{
+-    /*
+-     * This function will cause RM to relinquish control of the VGA ACPI device.
+-     */
+-    acpi_status status;
+-    union acpi_object control_argument_0 = { ACPI_TYPE_INTEGER };
+-    struct acpi_object_list control_argument_list = { 0, NULL };
+-    nv_acpi_t *pNvAcpiObject = device->driver_data;
+-
+-
+-    pNvAcpiObject->default_display_mask = 0;
+-
+-    // arg 0, bits 1:0, 1 = disable events
+-    control_argument_0.integer.type = ACPI_TYPE_INTEGER;
+-    control_argument_0.integer.value = 0x1;
+-
+-    // listify it
+-    control_argument_list.count = 1;
+-    control_argument_list.pointer = &control_argument_0;
+-
+-    // _DOS method takes 1 argument and returns nothing
+-    status = acpi_evaluate_object(device->handle, "_DOS", &control_argument_list, NULL);
+-
+-    if (ACPI_FAILURE(status))
+-    {
+-        nv_printf(NV_DBG_INFO,
+-            "NVRM: nv_acpi_remove: failed to disable display switch events (%d)!\n", status);
+-    }
+-
+-    if (pNvAcpiObject->notify_handler_installed)
+-    {
+-        // remove event notifier
+-        status = acpi_remove_notify_handler(device->handle, ACPI_DEVICE_NOTIFY, nv_acpi_event);
+-    }
+-
+-    if (pNvAcpiObject->notify_handler_installed &&
+-        ACPI_FAILURE(status))
+-    {
+-        nv_printf(NV_DBG_INFO,
+-            "NVRM: nv_acpi_remove: failed to remove event notification handler (%d)!\n", status);
+-    }
+-    else
+-    {
+-        nv_kmem_cache_free_stack(pNvAcpiObject->sp);
+-        os_free_mem((void *)pNvAcpiObject);
+-        module_put(THIS_MODULE);
+-        device->driver_data = NULL;
+-    }
+-
+-    return status;
+-}
+-
+-/*
+- * The ACPI specification defines IDs for various ACPI video
+- * extension events like display switch events, AC/battery
+- * events, docking events, etc..
+- * Whenever an ACPI event is received by the corresponding
+- * event handler installed within the core NVIDIA driver, the
+- * code can verify the event ID before processing it.
+- */
+-#define ACPI_DISPLAY_DEVICE_CHANGE_EVENT     0x80
+-#define NVIF_NOTIFY_DISPLAY_DETECT           0xCB
+-#define NVIF_DISPLAY_DEVICE_CHANGE_EVENT     NVIF_NOTIFY_DISPLAY_DETECT
+-static void nv_acpi_event(acpi_handle handle, u32 event_type, void *data)
+-{
+-    /*
+-     * This function will handle acpi events from the linux kernel, used
+-     * to detect notifications from the VGA device.
+-     */
+-    nv_acpi_t *pNvAcpiObject = data;
+-    u32 event_val = 0;
+-    unsigned long long state;
+-    int status = 0;
+-    int device_counter = 0;
+-
+-    if (event_type == NVIF_DISPLAY_DEVICE_CHANGE_EVENT)
+-    {
+-        /* We are getting NVIF events on this machine. We arent putting a very
+-           extensive handling in-place to communicate back with SBIOS, know
+-           the next enabled devices, and then do the switch. We just
+-           pass a default display switch event, so that X-driver decides
+-           the switching policy itself. */
+-        rm_system_event(pNvAcpiObject->sp, NV_SYSTEM_ACPI_DISPLAY_SWITCH_EVENT, 0);
+-    }
+-    if (event_type == ACPI_DISPLAY_DEVICE_CHANGE_EVENT)
+-    {
+-        if (pNvAcpiObject->default_display_mask != 1)
+-        {
+-            while ((device_counter < NV_MAXNUM_DISPLAY_DEVICES) &&
+-                   (pNvAcpiObject->pNvVideo[device_counter].dev_handle))
+-            {
+-                acpi_handle dev_handle = pNvAcpiObject->pNvVideo[device_counter].dev_handle;
+-                int dev_id = pNvAcpiObject->pNvVideo[device_counter].dev_id;
+-
+-                status = acpi_evaluate_integer(dev_handle,
+-                                               "_DGS",
+-                                               NULL,
+-                                               &state);
+-                if (ACPI_FAILURE(status))
+-                {
+-                    nv_printf(NV_DBG_INFO,
+-                    "NVRM: nv_acpi_event: failed to query _DGS method for display device 0x%x\n",
+-                    dev_id);
+-                }
+-                else if (state)
+-                {
+-                    /* Check if the device is a CRT ...*/
+-                    if (dev_id == 0x0100)
+-                    {
+-                        event_val |= NV_HOTKEY_STATUS_DISPLAY_ENABLE_CRT;
+-                    }
+-                    /* device-id for a TV */
+-                    else if (dev_id == 0x0200)
+-                    {
+-                        event_val |= NV_HOTKEY_STATUS_DISPLAY_ENABLE_TV;
+-                    }
+-                    else if ((dev_id == 0x0110) ||  /* device id for internal LCD */
+-                             (dev_id == 0x0118) ||  /* alternate ACPI ID for the
+-                                                                        internal LCD */
+-                             (dev_id == 0x0400))    /* ACPI spec 3.0 specified
+-                                                 device id for a internal LCD*/
+-                    {
+-                        event_val |= NV_HOTKEY_STATUS_DISPLAY_ENABLE_LCD;
+-                    }
+-                    else if ((dev_id == 0x0111) || /* the set
+-                                                    of possible device-ids for a DFP */
+-                             (dev_id == 0x0120) ||
+-                             (dev_id == 0x0300))   /* ACPI spec 3.0 specified
+-                                                    device id for non-LVDS DFP */
+-                    {
+-                        event_val |= NV_HOTKEY_STATUS_DISPLAY_ENABLE_DFP;
+-                    }
+-                }
+-                device_counter++;
+-            }
+-        }
+-
+-        nv_printf(NV_DBG_INFO,
+-        "NVRM: nv_acpi_event: Event-type 0x%x, Event-val 0x%x\n",
+-        event_type, event_val);
+-
+-        rm_system_event(pNvAcpiObject->sp, NV_SYSTEM_ACPI_DISPLAY_SWITCH_EVENT, event_val);
+-    }
+-
+-    // no unsubscription or re-enable necessary. Once DOD has been set, we are go.
+-    // once we are subscribed to ACPI events, we don't have to re-subscribe unless
+-    // unsubscribe.
+-}
+-
+ NV_STATUS NV_API_CALL nv_acpi_get_powersource(NvU32 *ac_plugged)
+ {
+     unsigned long long val;
+@@ -618,11 +233,6 @@ static void nv_uninstall_notifier(nv_acpi_t *pNvAcpiObject, acpi_notify_handler
+ 
+ void NV_API_CALL nv_acpi_methods_init(NvU32 *handlesPresent)
+ {
+-#if defined(NV_ACPI_BUS_GET_DEVICE_PRESENT)
+-    struct acpi_device *device = NULL;
+-    int retVal = -1;
+-#endif
+-
+     if (!handlesPresent) // Caller passed us invalid pointer.
+         return;
+ 
+@@ -634,32 +244,6 @@ void NV_API_CALL nv_acpi_methods_init(NvU32 *handlesPresent)
+     if (nvif_handle)
+     {
+         *handlesPresent = NV_ACPI_NVIF_HANDLE_PRESENT;
+-#if defined(NV_ACPI_BUS_GET_DEVICE_PRESENT)
+-        do
+-        {
+-            if (!nvif_parent_gpu_handle) /* unknown error */
+-                break;
+-
+-            retVal = acpi_bus_get_device(nvif_parent_gpu_handle, &device);
+-
+-            if (ACPI_FAILURE(retVal) || !device)
+-                break;
+-
+-            if (device->driver_data)
+-            {
+-                nvif_parent_gpu_handle = NULL;
+-                break;  /* Someone else has already populated this device
+-                           nodes' structures. So nothing more to be done */
+-            }
+-
+-            device->driver_data  = nv_install_notifier(device->handle, nv_acpi_event);
+-
+-
+-            if (!device->driver_data)
+-                nvif_parent_gpu_handle = NULL;
+-
+-        } while (0);
+-#endif
+     }
+ 
+     if (wmmx_handle)
+@@ -691,7 +275,6 @@ acpi_status nv_acpi_find_methods(
+     if (!acpi_get_handle(handle, "NVIF", &method_handle))
+     {
+         nvif_handle = method_handle;
+-        nvif_parent_gpu_handle = handle;
+     }
+ 
+     if (!acpi_get_handle(handle, "WMMX", &method_handle))
+@@ -710,8 +293,6 @@ acpi_status nv_acpi_find_methods(
+ 
+ void NV_API_CALL nv_acpi_methods_uninit(void)
+ {
+-    struct acpi_device *device = NULL;
+-
+     nvif_handle = NULL;
+     wmmx_handle = NULL;
+ 
+@@ -723,20 +304,6 @@ void NV_API_CALL nv_acpi_methods_uninit(void)
+         psr_device_handle = NULL;
+         psr_nv_acpi_object = NULL;
+     }
+-
+-    if (nvif_parent_gpu_handle == NULL)
+-        return;
+-
+-#if defined(NV_ACPI_BUS_GET_DEVICE_PRESENT)
+-    acpi_bus_get_device(nvif_parent_gpu_handle, &device);
+-
+-    nv_uninstall_notifier(device->driver_data, nv_acpi_event);
+-#endif
+-
+-    device->driver_data = NULL;
+-    nvif_parent_gpu_handle = NULL;
+-
+-    return;
+ }
+ 
+ static NV_STATUS nv_acpi_extract_integer(
+@@ -1114,12 +681,11 @@ NV_STATUS NV_API_CALL nv_acpi_ddc_method(
+ )
+ {
+     acpi_status status;
+-    struct acpi_device *device = NULL;
+     union acpi_object *ddc = NULL;
+-    struct list_head *node, *next;
+     NvU32 i, largestEdidSize;
+     acpi_handle dev_handle  = NULL;
+     acpi_handle lcd_dev_handle  = NULL;
++    acpi_handle handle = NULL;
+ 
+     if (!nv_acpi_get_device_handle(nv, &dev_handle))
+         return NV_ERR_NOT_SUPPORTED;
+@@ -1127,15 +693,6 @@ NV_STATUS NV_API_CALL nv_acpi_ddc_method(
+     if (!dev_handle)
+         return NV_ERR_INVALID_ARGUMENT;
+ 
+-#if defined(NV_ACPI_BUS_GET_DEVICE_PRESENT)
+-    status = acpi_bus_get_device(dev_handle, &device);
+-#else
+-    return NV_ERR_NOT_SUPPORTED;
+-#endif
+-
+-    if (ACPI_FAILURE(status) || !device)
+-        return NV_ERR_INVALID_ARGUMENT;
+-
+     if (!NV_MAY_SLEEP())
+     {
+ #if defined(DEBUG)
+@@ -1146,16 +703,16 @@ NV_STATUS NV_API_CALL nv_acpi_ddc_method(
+         return NV_ERR_NOT_SUPPORTED;
+     }
+ 
+-    list_for_each_safe(node, next, &device->children)
++    while (lcd_dev_handle == NULL)
+     {
+         unsigned long long device_id = 0;
+-        struct acpi_device *dev =
+-            list_entry(node, struct acpi_device, node);
+ 
+-        if (!dev)
+-            continue;
++        status = acpi_get_next_object(ACPI_TYPE_DEVICE, dev_handle,
++                                      handle, &handle);
++        if (ACPI_FAILURE(status) || (handle == NULL))
++            break;
+ 
+-        status = acpi_evaluate_integer(dev->handle, "_ADR", NULL, &device_id);
++        status = acpi_evaluate_integer(handle, "_ADR", NULL, &device_id);
+         if (ACPI_FAILURE(status))
+             /* Couldnt query device_id for this device */
+             continue;
+@@ -1165,16 +722,13 @@ NV_STATUS NV_API_CALL nv_acpi_ddc_method(
+             case 0x0118:
+             case 0x0400:
+             case 0xA420:
+-                lcd_dev_handle = dev->handle;
++                lcd_dev_handle = handle;
+                 nv_printf(NV_DBG_INFO, "NVRM: %s Found LCD: %x\n",
+                           __FUNCTION__, device_id);
+                 break;
+             default:
+                 break;
+         }
+-
+-        if (lcd_dev_handle != NULL)
+-            break;
+     }
+ 
+     if (lcd_dev_handle == NULL)
+@@ -1524,15 +1078,14 @@ NV_STATUS NV_API_CALL nv_acpi_mux_method(
+ )
+ {
+     acpi_status status;
+-    struct acpi_device *device    = NULL;
+     struct acpi_buffer output     = { ACPI_ALLOCATE_BUFFER, NULL };
+     union acpi_object *mux        = NULL;
+     union acpi_object mux_arg     = { ACPI_TYPE_INTEGER };
+     struct acpi_object_list input = { 1, &mux_arg };
+     acpi_handle dev_handle        = NULL;
+     acpi_handle mux_dev_handle    = NULL;
++    acpi_handle handle            = NULL;
+     unsigned long long device_id  = 0;
+-    struct list_head *node, *next;
+ 
+     if ((strcmp(pMethodName, "MXDS") != 0)
+         && (strcmp(pMethodName, "MXDM") != 0))
+@@ -1553,16 +1106,6 @@ NV_STATUS NV_API_CALL nv_acpi_mux_method(
+     if (!dev_handle)
+         return NV_ERR_INVALID_ARGUMENT;
+ 
+-#if defined(NV_ACPI_BUS_GET_DEVICE_PRESENT)
+-    status = acpi_bus_get_device(dev_handle, &device);
+-#else
+-    return NV_ERR_NOT_SUPPORTED;
+-#endif
+-
+-
+-    if (ACPI_FAILURE(status) || !device)
+-        return NV_ERR_INVALID_ARGUMENT;
+-
+     if (!NV_MAY_SLEEP())
+     {
+ #if defined(DEBUG)
+@@ -1571,23 +1114,16 @@ NV_STATUS NV_API_CALL nv_acpi_mux_method(
+         return NV_ERR_NOT_SUPPORTED;
+     }
+ 
+-    list_for_each_safe(node, next, &device->children)
++    while (mux_dev_handle == NULL)
+     {
+-        struct acpi_device *dev = list_entry(node, struct acpi_device, node);
+-
+-        if (!dev)
+-            continue;
+-
+-        status = acpi_evaluate_integer(dev->handle, "_ADR", NULL, &device_id);
+-        if (ACPI_FAILURE(status))
+-            /* Could not query device_id for this device */
+-            continue;
+-
+-        if (device_id == muxAcpiId)
+-        {
+-            mux_dev_handle = dev->handle;
++        status = acpi_get_next_object(ACPI_TYPE_DEVICE, dev_handle,
++                                      handle, &handle);
++        if (ACPI_FAILURE(status) || (handle == NULL))
+             break;
+-        }
++
++        status = acpi_evaluate_integer(handle, "_ADR", NULL, &device_id);
++        if (ACPI_SUCCESS(status) && (device_id == muxAcpiId))
++            mux_dev_handle = handle;
+     }
+ 
+     if (mux_dev_handle == NULL)
+@@ -1734,16 +1270,6 @@ NvBool NV_API_CALL nv_acpi_is_battery_present(void)
+ 
+ #else // NV_LINUX_ACPI_EVENTS_SUPPORTED
+ 
+-int nv_acpi_init(void)
+-{
+-    return 0;
+-}
+-
+-int nv_acpi_uninit(void)
+-{
+-    return 0;
+-}
+-
+ void NV_API_CALL nv_acpi_methods_init(NvU32 *handlePresent)
+ {
+     *handlePresent = 0;
+diff --git a/kernel-dkms/nvidia/nv.c b/kernel-dkms/nvidia/nv.c
+index ab7d17c..f378b6d 100644
+--- a/kernel-dkms/nvidia/nv.c
++++ b/kernel-dkms/nvidia/nv.c
+@@ -2694,7 +2694,6 @@ nvidia_ctl_open(
+     nv_linux_state_t *nvl = &nv_ctl_device;
+     nv_state_t *nv = NV_STATE_PTR(nvl);
+     nv_linux_file_private_t *nvlfp = NV_GET_LINUX_FILE_PRIVATE(file);
+-    static int count = 0;
+ 
+     nv_printf(NV_DBG_INFO, "NVRM: nvidia_ctl_open\n");
+ 
+@@ -2706,13 +2705,6 @@ nvidia_ctl_open(
+     if (NV_ATOMIC_READ(nvl->usage_count) == 0)
+     {
+         nv->flags |= (NV_FLAG_OPEN | NV_FLAG_CONTROL);
+-
+-        if ((nv_acpi_init() < 0) &&
+-            (count++ < NV_MAX_RECURRING_WARNING_MESSAGES))
+-        {
+-            nv_printf(NV_DBG_ERRORS,
+-                "NVRM: failed to register with the ACPI subsystem!\n");
+-        }
+     }
+ 
+     NV_ATOMIC_INC(nvl->usage_count);
+@@ -2736,7 +2728,6 @@ nvidia_ctl_close(
+     nv_state_t *nv = NV_STATE_PTR(nvl);
+     nv_linux_file_private_t *nvlfp = NV_GET_LINUX_FILE_PRIVATE(file);
+     nvidia_stack_t *sp = nvlfp->sp;
+-    static int count = 0;
+     unsigned int i;
+ 
+     nv_printf(NV_DBG_INFO, "NVRM: nvidia_ctl_close\n");
+@@ -2745,13 +2736,6 @@ nvidia_ctl_close(
+     if (NV_ATOMIC_DEC_AND_TEST(nvl->usage_count))
+     {
+         nv->flags &= ~NV_FLAG_OPEN;
+-
+-        if ((nv_acpi_uninit() < 0) &&
+-            (count++ < NV_MAX_RECURRING_WARNING_MESSAGES))
+-        {
+-            nv_printf(NV_DBG_ERRORS,
+-                "NVRM: failed to unregister from the ACPI subsystem!\n");
+-        }
+     }
+     up(&nvl->ldata_lock);
+ 
+@@ -5438,7 +5422,19 @@ NvBool NV_API_CALL nv_s2idle_pm_configured(void)
+         return NV_FALSE;
+     }
+ 
++    /*
++     * init_sync_kiocb() internally uses GPL licensed __get_task_ioprio() from
++     * v5.20-rc1.
++     */
++#if defined(NV_GET_TASK_IOPRIO_PRESENT)
++    memset(&kiocb, 0, sizeof(kiocb));
++    kiocb.ki_filp = file;
++    kiocb.ki_flags = iocb_flags(file);
++    kiocb.ki_ioprio = IOPRIO_DEFAULT;
++#else
+     init_sync_kiocb(&kiocb, file);
++#endif
++
+     kiocb.ki_pos = 0;
+     iov_iter_kvec(&iter, READ, &iov, 1, sizeof(buf));
+ 
+diff --git a/kernel-dkms/nvidia/nvidia.Kbuild b/kernel-dkms/nvidia/nvidia.Kbuild
+index f1d9b3f..7957027 100644
+--- a/kernel-dkms/nvidia/nvidia.Kbuild
++++ b/kernel-dkms/nvidia/nvidia.Kbuild
+@@ -169,7 +169,7 @@ NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_gem_object_get
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_gem_object_put_unlocked
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += set_close_on_exec
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += dma_set_coherent_mask
+-NV_CONFTEST_FUNCTION_COMPILE_TESTS += acpi_bus_get_device
++NV_CONFTEST_FUNCTION_COMPILE_TESTS += get_task_ioprio
+ 
+ NV_CONFTEST_SYMBOL_COMPILE_TESTS += is_export_symbol_gpl_of_node_to_nid
+ NV_CONFTEST_SYMBOL_COMPILE_TESTS += is_export_symbol_gpl_sme_active
+@@ -189,7 +189,6 @@ NV_CONFTEST_SYMBOL_COMPILE_TESTS += is_export_symbol_present_dram_clk_to_mc_clk
+ NV_CONFTEST_SYMBOL_COMPILE_TESTS += is_export_symbol_present_get_dram_num_channels
+ NV_CONFTEST_SYMBOL_COMPILE_TESTS += is_export_symbol_present_tegra_dram_types
+ 
+-NV_CONFTEST_TYPE_COMPILE_TESTS += acpi_op_remove
+ NV_CONFTEST_TYPE_COMPILE_TESTS += file_operations
+ NV_CONFTEST_TYPE_COMPILE_TESTS += file_inode
+ NV_CONFTEST_TYPE_COMPILE_TESTS += kuid_t
+-- 
+2.38.0
+


### PR DESCRIPTION
[1] https://github.com/NVIDIA/open-gpu-kernel-modules

Specifically, parts of these two commits:
https://github.com/NVIDIA/open-gpu-kernel-modules/commit/965db985520c0c2aefa56dc2e81f9bfa67e91375 https://github.com/NVIDIA/open-gpu-kernel-modules/commit/98553501593ef05bddcc438689ed1136f732d40a

The patch also adds __get_task_ioprio() support when detected via conftest

Additionally, add 470.x to the whitelist for applying the drm_framebuffer inclusion as in https://github.com/Frogging-Family/nvidia-all/commit/f56d6244c24022cfa8b018822c47e274c90dbeac

Tested to work on NVIDIA GK107 [GeForce GTX 650] with 6.0.0-arch1-1

Signed-off-by: Jebaitedneko <Jebaitedneko@gmail.com>