### PR TITLE
525 series

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -48,30 +48,34 @@ if [ -z "$_driver_version" ] || [ "$_driver_version" = "latest" ] || [ -z "$_dri
     fi
   fi
   if [[ -z $CONDITION ]]; then
-    read -p "    What driver version do you want?`echo $'\n    > 1.Vulkan dev: 515.49.24\n      2.520 series: 520.56.06\n      3.515 series: 515.76\n      4.510 series: 510.85.02\n      5.495 series: 495.46\n      6.470 series: 470.141.03\n      7.Older series\n      8.Custom version (396.xx series or higher)\n    choice[1-8?]: '`" CONDITION;
+    read -p "    What driver version do you want?`echo $'\n    > 1.Vulkan dev: 515.49.24\n      2.525 series: 525.53\n      3.520 series: 520.56.06\n      4.515 series: 515.76\n      5.510 series: 510.85.02\n      6.495 series: 495.46\n      7.470 series: 470.141.03\n      8.Older series\n      9.Custom version (396.xx series or higher)\n    choice[1-9?]: '`" CONDITION;
   fi
     # This will be treated as the latest regular driver.
     if [ "$CONDITION" = "2" ]; then
+      echo '_driver_version=525.53' > options
+      echo '_md5sum=18f2932eb0df824c459fab8f8f23c689' >> options
+      echo '_driver_branch=regular' >> options
+    elif [ "$CONDITION" = "3" ]; then
       echo '_driver_version=520.56.06' > options
       echo '_md5sum=18136ef051cbfc3850e88aa5184b31b8' >> options
       echo '_driver_branch=regular' >> options
-    elif [ "$CONDITION" = "3" ]; then
+    elif [ "$CONDITION" = "4" ]; then
       echo '_driver_version=515.76' > options
       echo '_md5sum=1e740900bf47cf4574e95702125f1898' >> options
       echo '_driver_branch=regular' >> options
-    elif [ "$CONDITION" = "4" ]; then
+    elif [ "$CONDITION" = "5" ]; then
       echo '_driver_version=510.85.02' > options
       echo '_md5sum=0367f772fc61bccecee8559c4fe9bb3d' >> options
       echo '_driver_branch=regular' >> options
-    elif [ "$CONDITION" = "5" ]; then
+    elif [ "$CONDITION" = "6" ]; then
       echo '_driver_version=495.46' > options
       echo '_md5sum=db1d6b0f9e590249bbf940a99825f000' >> options
       echo '_driver_branch=regular' >> options
-    elif [ "$CONDITION" = "6" ]; then
+    elif [ "$CONDITION" = "7" ]; then
       echo '_driver_version=470.141.03' > options
       echo '_md5sum=ff6d869676ddfd7852aa7de77d7a0eb9' >> options
       echo '_driver_branch=regular' >> options
-    elif [ "$CONDITION" = "7" ]; then
+    elif [ "$CONDITION" = "8" ]; then
       read -p "    Which legacy driver version do you want?`echo $'\n    > 1.465 series: 465.31\n      2.460 series: 460.91.03\n      3.455 series: 455.45.01\n      4.450 series: 450.119.03\n      5.440 series: 440.100 (kernel 5.8 or lower)\n      6.435 series: 435.21  (kernel 5.6 or lower)\n      7.430 series: 430.64  (kernel 5.5 or lower)\n      8.418 series: 418.113 (kernel 5.5 or lower)\n      9.415 series: 415.27  (kernel 5.4 or lower)\n      10.410 series: 410.104 (kernel 5.5 or lower)\n      11.396 series: 396.54  (kernel 5.3 or lower, 5.1 or lower recommended)\n    choice[1-11?]: '`" CONDITION;
       if [ "$CONDITION" = "2" ]; then
         echo '_driver_version=460.91.03' > options
@@ -118,7 +122,7 @@ if [ -z "$_driver_version" ] || [ "$_driver_version" = "latest" ] || [ -z "$_dri
         echo '_md5sum=4996eefa54392b0c9541d22e88abab66' >> options
         echo '_driver_branch=regular' >> options
       fi
-    elif [ "$CONDITION" = "8" ]; then
+    elif [ "$CONDITION" = "9" ]; then
       echo '_driver_version=custom' > options
       read -p "What branch do you want?`echo $'\n> 1.Stable or regular beta\n  2.Vulkan dev\nchoice[1-2?]: '`" CONDITION;
       if [ "$CONDITION" = "2" ]; then
@@ -277,7 +281,7 @@ fi
 
 pkgname=("${_pkgname_array[@]}")
 pkgver=$_driver_version
-pkgrel=225
+pkgrel=226
 arch=('x86_64')
 url="http://www.nvidia.com/"
 license=('custom:NVIDIA')
@@ -1258,22 +1262,29 @@ package_opencl-$_branchname-tkg() {
 }
 EOF
 
-if [[ $pkgver = 396* ]]; then
-  _eglwver="1.0.3"
-elif [[ $pkgver = 410* ]] || [[ $pkgver = 415* ]]; then
-  _eglwver="1.1.0"
-elif [[ $pkgver = 418* ]] || [[ $pkgver = 430* ]]; then
-  _eglwver="1.1.2"
-elif [[ $pkgver = 435* ]]; then
-  _eglwver="1.1.3"
-elif [[ $pkgver = 44* ]] || [[ $pkgver = 450* ]]; then
-  _eglwver="1.1.4"
-elif [[ $pkgver = 455* ]] || [[ $pkgver = 460* ]] || [[ $pkgver = 465* ]]; then
-  _eglwver="1.1.5"
+#egl-wayland version
+if (( ${pkgver%%.*} >= 525 )); then
+  _eglwver="1.1.10"
+elif (( ${pkgver%%.*} >= 495 )); then
+  _eglwver="1.1.9"
 elif [[ $pkgver = 470* ]]; then
   _eglwver="1.1.7"
-else
-  _eglwver="1.1.9"
+elif (( ${pkgver%%.*} >= 455 )); then
+  _eglwver="1.1.5"
+elif (( ${pkgver%%.*} >= 440 )); then
+  _eglwver="1.1.4"
+elif [[ $pkgver = 435* ]]; then
+  _eglwver="1.1.3"
+elif (( ${pkgver%%.*} >= 418 )); then
+  _eglwver="1.1.2"
+elif (( ${pkgver%%.*} >= 410 )); then
+  _eglwver="1.1.0"
+elif [[ $pkgver = 396* ]]; then
+  _eglwver="1.0.3"
+fi
+
+#egl-gbm  version
+if (( ${pkgver%%.*} >= 495 )); then
   _eglgver="1.1.0"
 fi
 
@@ -1363,6 +1374,10 @@ nvidia-utils-tkg() {
     install -D -m755 "libnvidia-cfg.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-cfg.so.${pkgver}"
     install -D -m755 "libnvidia-ml.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-ml.so.${pkgver}"
     install -D -m755 "libnvidia-glvkspirv.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-glvkspirv.so.${pkgver}"
+
+    if [[ -e libnvidia-api.so.1 ]]; then
+      install -D -m755 "libnvidia-api.so.1" "${pkgdir}/usr/lib/libnvidia-api.so.1"
+    fi
 
     # Allocator library
     if [[ -e libnvidia-allocator.so.${pkgver} ]]; then
@@ -1509,7 +1524,10 @@ nvidia-utils-tkg() {
     fi
 
     # gsp firmware
-    if (( ${pkgver%%.*} >= 465 )); then
+    if (( ${pkgver%%.*} >= 525 )); then
+      install -D -m644 firmware/gsp_ad10x.bin "${pkgdir}/usr/lib/firmware/nvidia/${pkgver}/gsp_ad10x.bin"
+      install -D -m644 firmware/gsp_tu10x.bin "${pkgdir}/usr/lib/firmware/nvidia/${pkgver}/gsp_tu10x.bin"
+    elif (( ${pkgver%%.*} >= 465 )); then
       install -D -m644 firmware/gsp.bin "${pkgdir}/usr/lib/firmware/nvidia/${pkgver}/gsp.bin"
     fi
 


### PR DESCRIPTION
Introduce the new 525 series:

Noticeable changes:
- GSP firmware now have multiple files
- There is a new (undocumented) file libnvidia-api.so.1

Significant change:
- I've changed how we handle the libnvidia-egl-wayland and libnvidia-egl-gbm versions. I suggest to keep the recent versions first, so we avoid going through all the if-statements until we get to the end. I think it is less prone to errors as the versions grow with time.

I don't know whether you'll prefer revert this, but I think, at least, we should split the logic for egl-wayland and egl-gbm versions, since they have separated release cycles.
