### PR TITLE
nvidia-utils: add missing libnvidia-nvvm.so

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1444,6 +1444,13 @@ nvidia-utils-tkg() {
     # nvvm
     if [[ $pkgver = 470* ]]; then
        install -D -m755 "libnvidia-nvvm.so.4.0.0" "${pkgdir}/usr/lib/libnvidia-nvvm.so.4.0.0"
+       ln -s "libnvidia-nvvm.so.4.0.0" "${pkgdir}/usr/lib/libnvidia-nvvm.so.${pkgver}"
+       ln -s "libnvidia-nvvm.so.4.0.0" "${pkgdir}/usr/lib/libnvidia-nvvm.so"
+    fi
+    if [[ -e libnvidia-nvvm.so.${pkgver} ]]; then
+      install -D -m755 "libnvidia-nvvm.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-nvvm.so.${pkgver}"
+      ln -s "libnvidia-nvvm.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-nvvm.so.4"
+      ln -s "libnvidia-nvvm.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-nvvm.so"
     fi
 
     # Fat (multiarchitecture) binary loader

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -281,7 +281,7 @@ fi
 
 pkgname=("${_pkgname_array[@]}")
 pkgver=$_driver_version
-pkgrel=226
+pkgrel=227
 arch=('x86_64')
 url="http://www.nvidia.com/"
 license=('custom:NVIDIA')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1442,15 +1442,14 @@ nvidia-utils-tkg() {
     install -D -m755 "libnvidia-ptxjitcompiler.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-ptxjitcompiler.so.${pkgver}"
 
     # nvvm
-    if [[ $pkgver = 470* ]]; then
-       install -D -m755 "libnvidia-nvvm.so.4.0.0" "${pkgdir}/usr/lib/libnvidia-nvvm.so.4.0.0"
-       ln -s "libnvidia-nvvm.so.4.0.0" "${pkgdir}/usr/lib/libnvidia-nvvm.so.${pkgver}"
-       ln -s "libnvidia-nvvm.so.4.0.0" "${pkgdir}/usr/lib/libnvidia-nvvm.so"
-    fi
     if [[ -e libnvidia-nvvm.so.${pkgver} ]]; then
       install -D -m755 "libnvidia-nvvm.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-nvvm.so.${pkgver}"
       ln -s "libnvidia-nvvm.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-nvvm.so.4"
       ln -s "libnvidia-nvvm.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-nvvm.so"
+    elif [[ -e libnvidia-nvvm.so.4.0.0 ]]; then
+      install -D -m755 "libnvidia-nvvm.so.4.0.0" "${pkgdir}/usr/lib/libnvidia-nvvm.so.4.0.0"
+      ln -s "libnvidia-nvvm.so.4.0.0" "${pkgdir}/usr/lib/libnvidia-nvvm.so.${pkgver}"
+      ln -s "libnvidia-nvvm.so.4.0.0" "${pkgdir}/usr/lib/libnvidia-nvvm.so"
     fi
 
     # Fat (multiarchitecture) binary loader


### PR DESCRIPTION
I've found the missing libnvidia-nvvm.so.

This accounts for the difference in ~80MB that @ptr1337 pointed out.

Apart from that, the only difference I could only point out that we install:
`install -D -m644 "nvidia_layers.json" "${pkgdir}/usr/share/vulkan/explicit_layer.d/nvidia_layers.json"`

and upstream installs in 
`install -D -m644 "nvidia_layers.json" "${pkgdir}/usr/share/vulkan/implicit_layer.d/nvidia_layers.json"`

I don't know whether it should be in implicit_layer.d.
