### PR TITLE
Fix 6.2 patchset for nvidia, nvidia-dkms will compile also now for 6.…

### DIFF
--- a/patches/kernel-6.2.patch
+++ b/patches/kernel-6.2.patch
@@ -1,28 +1,86 @@
-diff --git a/nvidia-drm/nvidia-drm-connector.c b/nvidia-drm/nvidia-drm-connector.c
-index 77a6120..b05dc78 100644
+From ac78402fe504591eeb98a4212e695731755d6b25 Mon Sep 17 00:00:00 2001
+From: Peter Jung <admin@ptr1337.dev>
+Date: Tue, 27 Dec 2022 18:08:48 +0100
+Subject: [PATCH] Tentative fix for NVIDIA 525 driver for Linux 6.2-rc1
+
+Signed-off-by: Peter Jung <admin@ptr1337.dev>
+---
+ kernel-dkms/nvidia-drm/nvidia-drm-connector.c | 22 +++++++++++++++++++
+ kernel-dkms/nvidia-drm/nvidia-drm-drv.c       |  4 ++++
+ 2 files changed, 26 insertions(+)
+
+diff --git a/kernel-dkms/nvidia-drm/nvidia-drm-connector.c b/kernel-dkms/nvidia-drm/nvidia-drm-connector.c
+index 77a6120..cd92bb2 100644
 --- a/kernel-dkms/nvidia-drm/nvidia-drm-connector.c
 +++ b/kernel-dkms/nvidia-drm/nvidia-drm-connector.c
-@@ -98,7 +98,7 @@ __nv_drm_detect_encoder(struct NvKmsKapiDynamicDisplayParams *pDetectParams,
+@@ -20,6 +20,8 @@
+  * DEALINGS IN THE SOFTWARE.
+  */
+ 
++#include <linux/version.h>
++#include <drm/drm_edid.h>
+ #include "nvidia-drm-conftest.h" /* NV_DRM_ATOMIC_MODESET_AVAILABLE */
+ 
+ #if defined(NV_DRM_ATOMIC_MODESET_AVAILABLE)
+@@ -98,6 +100,7 @@ __nv_drm_detect_encoder(struct NvKmsKapiDynamicDisplayParams *pDetectParams,
              break;
      }
-
--    if (connector->override_edid) {
-+    if (connector->edid_override) {
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+     if (connector->override_edid) {
          const struct drm_property_blob *edid = connector->edid_blob_ptr;
-
-         if (edid->length <= sizeof(pDetectParams->edid.buffer)) {
-diff --git a/nvidia-drm/nvidia-drm-drv.c b/nvidia-drm/nvidia-drm-drv.c
-index ac504ec..cc6626a 100644
+ 
+@@ -110,6 +113,25 @@ __nv_drm_detect_encoder(struct NvKmsKapiDynamicDisplayParams *pDetectParams,
+                     sizeof(pDetectParams->edid.buffer));
+         }
+     }
++#else
++    // Rel. commit "drm/edid: detach debugfs EDID override from EDID property update" (Jani Nikula, 24 Oct 2022)
++    // NOTE: HUGE HACK!
++    mutex_lock(&connector->edid_override_mutex);
++    if (connector->edid_override) {
++        const struct edid *edid = drm_edid_raw(connector->edid_override);
++        size_t edid_length = EDID_LENGTH * (edid->extensions + 1);
++        if (edid_length <= sizeof(pDetectParams->edid.buffer)) {
++            memcpy(pDetectParams->edid.buffer, edid, edid_length);
++            pDetectParams->edid.bufferSize = edid_length;
++            pDetectParams->overrideEdid = NV_TRUE;
++        } else {
++            WARN_ON(edid_length >
++                    sizeof(pDetectParams->edid.buffer));
++        }
++    }
++    mutex_unlock(&connector->edid_override_mutex);
++
++#endif
+ 
+     if (!nvKms->getDynamicDisplayInfo(nv_dev->pDevice, pDetectParams)) {
+         NV_DRM_DEV_LOG_ERR(
+diff --git a/kernel-dkms/nvidia-drm/nvidia-drm-drv.c b/kernel-dkms/nvidia-drm/nvidia-drm-drv.c
+index ac504ec..75ef54d 100644
 --- a/kernel-dkms/nvidia-drm/nvidia-drm-drv.c
 +++ b/kernel-dkms/nvidia-drm/nvidia-drm-drv.c
-@@ -257,10 +257,6 @@ nv_drm_init_mode_config(struct nv_drm_device *nv_dev,
+@@ -20,6 +20,7 @@
+  * DEALINGS IN THE SOFTWARE.
+  */
+ 
++#include <linux/version.h>
+ #include "nvidia-drm-conftest.h" /* NV_DRM_AVAILABLE and NV_DRM_DRM_GEM_H_PRESENT */
+ 
+ #include "nvidia-drm-priv.h"
+@@ -257,9 +258,12 @@ nv_drm_init_mode_config(struct nv_drm_device *nv_dev,
      dev->mode_config.preferred_depth = 24;
      dev->mode_config.prefer_shadow = 1;
-
--    /* Currently unused. Update when needed. */
--
--    dev->mode_config.fb_base = 0;
--
+ 
++// Rel. commit "drm: Remove drm_mode_config::fb_base" (Zack Rusin, 18 Oct 2022)
++#if defined(CONFIG_FB) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+     /* Currently unused. Update when needed. */
+ 
+     dev->mode_config.fb_base = 0;
++#endif
+ 
  #if defined(NV_DRM_CRTC_STATE_HAS_ASYNC_FLIP) || \
      defined(NV_DRM_CRTC_STATE_HAS_PAGEFLIP_FLAGS)
-     dev->mode_config.async_page_flip = true;
+-- 
+2.39.0
+


### PR DESCRIPTION
…1 or lower version correctly

Signed-off-by: Peter Jung <admin@ptr1337.dev>