### PR TITLE
Add Flatpak host GL driver support

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -27,6 +27,9 @@ _opencl="true"
 _nvsettings="true"
 _eglwayland="true"
 
+# Installs the NVIDIA drivers as a Flatpak extension; Useful if you're using developer drivers.
+_flatpak="true"
+
 # Either "vulkandev" for vulkan developer drivers or "regular" for all others
 _driver_branch=""
 


### PR DESCRIPTION
Closes https://github.com/Frogging-Family/nvidia-all/issues/155

Needs testing to be sure everything works properly. I don't own a NVIDIA GPU, so I can't do it.

You can test by installing, making sure /`var/lib/flatpak/extension/org.freedesktop.Platform.GL.host/x86_641.4` exists and is filled with the NVIDIA files, and running `FLATPAK_GL_DRIVERS=host flatpak run test.openglorvulkan.app`.

