### PR TITLE
Add support for vulkan dev 525.47.31

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -144,8 +144,8 @@ if [ -z "$_driver_version" ] || [ "$_driver_version" = "latest" ] || [ -z "$_dri
       echo "_driver_version=$_driver_version" >> options
     # This (condition 1) will be treated as the latest Vulkan developer driver.
     else
-      echo '_driver_version=525.47.27' > options
-      echo '_md5sum=a0cb80ac18553a8eed2acb0f30729c48' >> options
+      echo '_driver_version=525.47.31' > options
+      echo '_md5sum=00ec1951b2da0fd026457f880de8a68a' >> options
       echo '_driver_branch=vulkandev' >> options
     fi
 # Package type selector

--- a/patches/kernel-6.4.patch
+++ b/patches/kernel-6.4.patch
@@ -1,0 +1,26 @@
+Works around dumb_destroy error when compiling for kernel 6.4.0 or newer
+Copied/edited from Joan Bruguera's 470.xx patch
+See: https://gist.github.com/joanbm/77f0650d45747b9a4dc8e330ade2bf5c
+
+--- a/kernel-dkms/nvidia-drm/nvidia-drm-drv.c
++++ b/kernel-dkms/nvidia-drm/nvidia-drm-drv.c
+@@ -35,6 +35,7 @@
+ #include "nvidia-drm-gem-nvkms-memory.h"
+ #include "nvidia-drm-gem-user-memory.h"
+ #include "nvidia-drm-gem-dma-buf.h"
++#include <linux/version.h>
+
+ #if defined(NV_DRM_AVAILABLE)
+
+@@ -1436,7 +1437,11 @@ static void nv_drm_update_drm_driver_features(void)
+
+     nv_drm_driver.dumb_create      = nv_drm_dumb_create;
+     nv_drm_driver.dumb_map_offset  = nv_drm_dumb_map_offset;
+-    nv_drm_driver.dumb_destroy     = nv_drm_dumb_destroy;
++    // Rel. commit "drm: remove dumb_destroy callback" (Christian König, 26 Jan 2023)
++    // NB: No resources are leaked, the kernel releases the same resources by default
++    #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
++        nv_drm_driver.dumb_destroy     = nv_drm_dumb_destroy;
++    #endif
+ #endif /* NV_DRM_ATOMIC_MODESET_AVAILABLE */
+ }


### PR DESCRIPTION
> Vulkan Beta Driver Release Updates
> July 11th, 2023 - Windows 532.28, Linux 525.47.31
> 
> New:
> VK_KHR_cooperative_matrix
> VK_EXT_depth_bias_control
> VK_EXT_dynamic_rendering_unused_attachments
> VK_MESA_video_decode_av1 preliminary implementation for Ada GPUs
> VK_NV_displacement_micromap updated to version 2
> Vulkan video updates:
> VK_KHR_video_encode_queue version update 8->9
> VK_EXT_video_encode_h264 version update 10->11
> Fixes:
> Fix for VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT
> Fix 64-bit shader disk cache issues

https://developer.nvidia.com/vulkan-driver