### PR TITLE
Bump Vulkan Dev to 570.123.18

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -54,7 +54,7 @@ if [ -z "$_driver_version" ] || [ "$_driver_version" = "latest" ] || [ -z "$_dri
   warning "Please make sure you have the corresponding kernel headers package installed for each kernel on your system !\n"
 
   if [[ -z $CONDITION ]]; then
-    read -p "    Which driver version do you want?`echo $'\n    > 1.Vulkan dev: 570.123.14\n      2.575 series: 575.51.02\n      3.570 series: 570.144\n      4.565 series: 565.77\n      5.470 series: 470.256.02 (LTS kernel recommended)\n      6.Older series\n      7.Custom version (396.xx series or higher)\n    choice[1-7?]: '`" CONDITION;
+    read -p "    Which driver version do you want?`echo $'\n    > 1.Vulkan dev: 570.123.18\n      2.575 series: 575.51.02\n      3.570 series: 570.144\n      4.565 series: 565.77\n      5.470 series: 470.256.02 (LTS kernel recommended)\n      6.Older series\n      7.Custom version (396.xx series or higher)\n    choice[1-7?]: '`" CONDITION;
   fi
     # This will be treated as the latest regular driver.
     if [ "$CONDITION" = "2" ]; then
@@ -178,8 +178,8 @@ if [ -z "$_driver_version" ] || [ "$_driver_version" = "latest" ] || [ -z "$_dri
       echo "_driver_version=$_driver_version" >> options
     # This (condition 1) will be treated as the latest Vulkan developer driver.
     else
-      echo '_driver_version=570.123.14' > options
-      echo '_md5sum=5cadcfa3a68687ab3e0a69a6addbd80e' >> options
+      echo '_driver_version=570.123.18' > options
+      echo '_md5sum=1a66b0c42a5382cc03dadf93c1b27365' >> options
       echo '_driver_branch=vulkandev' >> options
     fi
 # Package type selector
@@ -1694,7 +1694,7 @@ package_opencl-$_branchname-tkg() {
 EOF
 
 #egl-wayland version
-if (( ${pkgver%%.*} >= 575 )) || [ "${pkgver}" = "570.123.14" ]; then
+if (( ${pkgver%%.*} >= 575 )) || [ "${pkgver}" = "570.123.18" ]; then
   _eglwver="1.1.19"
 elif (( ${pkgver%%.*} >= 570 )); then
   _eglwver="1.1.18"


### PR DESCRIPTION
Release June 8th: https://developer.nvidia.com/vulkan-driver


New:
* [VK_KHR_maintenance9](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_maintenance9.html)
* [VK_KHR_present_id2](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_present_id2.html)
* [VK_KHR_present_wait2](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_present_wait2.html)
* [VK_KHR_unified_image_layouts](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_unified_image_layouts.html)
* [VK_KHR_video_decode_vp9](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_video_decode_vp9.html)
* [VK_EXT_shader_float8](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_shader_float8.html)
* Added support for VK_NV_cooperative_vector cooperativeVectorTrainingFloat32Accumulation feature

Fixes:
* Fixed SPIR-V compilation crash that sometimes occured when NoInline was used
* Fixed SPIR-V compilation crash with some OpPhi uses
* VK_NV_cooperative_vector fixes and performance improvements
* Fixed crash that sometimes happened with geometry passthrough
* Fixed VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_RADIUS_BUFFER_BIT_NV functionality
* Fixed crash that sometimes happened with ray tracing pipeline compilation and populated pipeline cache
