### PR TITLE
Make libalpm initramfs hook optional

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2155,7 +2155,11 @@ if [ "$_dkms" = "false" ] || [ "$_dkms" = "full" ]; then
                 install -Dm644 /dev/stdin "${pkgdir}/usr/lib/modprobe.d/${pkgname}.conf"
       fi
 
-      install -Dm644 "${srcdir}/nvidia-tkg.hook" "${pkgdir}/usr/share/libalpm/hooks/nvidia-tkg.hook"
+      if [[ ! "$_disable_libalpm_hook" == "true" ]]; then
+        install -Dm644 "${srcdir}/nvidia-tkg.hook" "${pkgdir}/usr/share/libalpm/hooks/nvidia-tkg.hook"
+      else
+        echo "Skipping mkinitcpio hook due to user config"
+      fi 
   else
       pkgdesc="Full NVIDIA drivers' package for all kernels on the system (drivers and shared utilities and libraries)"
       depends=("nvidia-utils-tkg>=$pkgver" 'libglvnd')
@@ -2186,7 +2190,11 @@ if [ "$_dkms" = "false" ] || [ "$_dkms" = "full" ]; then
                 install -Dm644 /dev/stdin "${pkgdir}/etc/modules-load.d/${pkgname}.conf"
       fi
 
-      install -Dm644 "${srcdir}/nvidia-tkg.hook" "${pkgdir}/usr/share/libalpm/hooks/nvidia-tkg.hook"
+      if [[ ! "$_disable_libalpm_hook" == "true" ]]; then
+        install -Dm644 "${srcdir}/nvidia-tkg.hook" "${pkgdir}/usr/share/libalpm/hooks/nvidia-tkg.hook"
+      else
+        echo "Skipping mkinitcpio hook due to user config"
+      fi  
   fi
   }
 source /dev/stdin <<EOF
@@ -2337,8 +2345,11 @@ if [ "$_dkms" = "true" ] || [ "$_dkms" = "full" ]; then
       install -dm 755 "${pkgdir}"/usr/{lib/modprobe.d,src}
       cp -dr --no-preserve='ownership' kernel-dkms "${pkgdir}/usr/src/nvidia-${pkgver}"
 
-
-      install -Dm644 "${srcdir}/nvidia-tkg.hook" "${pkgdir}/usr/share/libalpm/hooks/nvidia-tkg.hook"
+      if [[ ! "$_disable_libalpm_hook" == "true" ]]; then
+        install -Dm644 "${srcdir}/nvidia-tkg.hook" "${pkgdir}/usr/share/libalpm/hooks/nvidia-tkg.hook"
+      else
+        echo "Skipping mkinitcpio hook due to user config"
+      fi 
 
       install -Dt "${pkgdir}/usr/share/licenses/${pkgname}" -m644 "${srcdir}/${_pkg}/LICENSE"
   fi

--- a/customization.cfg
+++ b/customization.cfg
@@ -65,7 +65,7 @@ _dkms=""
 _gcc15_fix="false"
 
 # Set to "true" to disable installing the libalpm hook for updating the driver in initramfs, installs otherwise.
-_disable_libalpm_hook="true"
+_disable_libalpm_hook=""
 
 ## LEGACY OPTIONS
 

--- a/customization.cfg
+++ b/customization.cfg
@@ -64,6 +64,8 @@ _dkms=""
 # Enable GCC 15 fixup patch
 _gcc15_fix="false"
 
+# Set to "true" to disable installing the libalpm hook for updating the driver in initramfs, installs otherwise.
+_disable_libalpm_hook="true"
 
 ## LEGACY OPTIONS
 


### PR DESCRIPTION
Adds a customization.cfg option to disable installing the pacman hook to rebuild initramfs.
As far as I can see the hook has had a history of being problematic, and i'm personally afflicted still by #222, I've been patching out the hook as I note there but it'd probably be better to just have an option for it, as I'm sure it might be helpful in other contexts as well.
If this is too niche an option I totally understand.