### PR TITLE
fix: Apply modeset patches to correct directory for open-source modules, breaking Wayland functionality

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -607,17 +607,17 @@ DEST_MODULE_LOCATION[4]="/kernel/drivers/video"' kernel-open/dkms.conf
     # Apply patches to original source before copying for DKMS (so both DKMS and regular builds get patched)
     if (( ${pkgver%%.*} >= 550 )) && (( ${pkgver%%.*} < 565 )); then
       msg2 "Applying make-modeset-fbdev-default.diff to kernel-open..."
-      ( cd "$srcdir"/"$_pkg"/kernel-open && patch -Np2 -i "$srcdir"/make-modeset-fbdev-default.diff )
+      ( cd "$srcdir"/${_srcbase}-${pkgver}/kernel-open && patch -Np2 -i "$srcdir"/make-modeset-fbdev-default.diff )
     fi
 
     if (( ${pkgver%%.*} == 565 )); then
       msg2 "Applying make-modeset-fbdev-default-565.diff to kernel-open..."
-      ( cd "$srcdir"/"$_pkg"/kernel-open && patch -Np2 -i "$srcdir"/make-modeset-fbdev-default-565.diff )
+      ( cd "$srcdir"/${_srcbase}-${pkgver}/kernel-open && patch -Np2 -i "$srcdir"/make-modeset-fbdev-default-565.diff )
     fi
 
     if (( ${pkgver%%.*} >= 570 )); then
       msg2 "Applying Enable-atomic-kernel-modesetting-by-default.diff to kernel-open..."
-      ( cd "$srcdir"/"$_pkg"/kernel-open && patch -Np2 -i "$srcdir"/Enable-atomic-kernel-modesetting-by-default.diff )
+      ( cd "$srcdir"/${_srcbase}-${pkgver}/kernel-open && patch -Np2 -i "$srcdir"/Enable-atomic-kernel-modesetting-by-default.diff )
     fi
 
     # Clean version for later copying for DKMS (now includes modeset patches)


### PR DESCRIPTION
Hey, something new.

I did some research online and came across this post: 
`https://forums.developer.nvidia.com/t/590-release-feedback-discussion/353310/45`
**This caused `nvidia-drm.modeset=1` and `nvidia-drm.fbdev=1` to NOT be enabled 
by default when using open-source modules, breaking Wayland functionality.**

I can confirm that I also always had to set `nvidia-drm.modeset=1` and `nvidia-drm.fbdev=1` as the kernel start parameter, otherwise the desktop wouldn't start and/or settings not applied.

I tested it again and it really seems that the `Enable-atomic-kernel-modesetting-by-default.diff` patch isn't being applied correctly in the build process in `$_pkg/kernel-open`. 
I think this is affected versions: 550+?

Oops! The commits I made previously were only applied to the DKMS. I've changed it back, but only after the DKMS build process; otherwise, it doesn't seem to apply the patch. As described.

Solution i ddid:
Apply modeset patches BEFORE the cp command to the original source
**but after dkms patches are applied. This way, both DKMS and regular builds
receive the modeset patches.**

KISS :frog: :heart: 

