### PR TITLE
fix for last PR https://github.com/Frogging-Family/nvidia-all/pull/325

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1909,7 +1909,7 @@ EOF
 
 nvidia-utils-tkg() {
   pkgdesc="NVIDIA driver utilities and libraries for 'nvidia-tkg'"
-  depends=('libglvnd' 'mesa' 'vulkan-icd-loader' 'egl-x11')
+  depends=('libglvnd' 'mesa' 'vulkan-icd-loader')
   if [ "$_eglgbm" = "external" ]; then
     depends+=('egl-gbm')
   fi


### PR DESCRIPTION
Yes, I didn't think it through. With a kernel update running and a non-DKMS module, it obviously won't recognize the running kernel – but it won't recognize a custom kernel either if it's not compiled and installed under a `linux` name.

The file conflict that was just located can be easily solved like this:

```bash

if (( ${pkgver%%.*} <= 590 )) && [[ -e 20_nvidia_xlib.json ]]; then 
install -D -m644 "20_nvidia_xlib.json" "${pkgdir}/usr/share/egl/egl_external_platform.d/20_nvidia_xlib.json"
fi
.....
if (( ${pkgver%%.*} <= 590 )) && [[ -e 20_nvidia_xcb.json ]]; then 
install -D -m644 "20_nvidia_xcb.json" "${pkgdir}/usr/share/egl/egl_external_platform.d/20_nvidia_xcb.json" 
fi
```
Maybe a double check is better add this, too:

```bash
if (( ${pkgver%%.*} >= 590 )); then

depends+=('egl-x11')

fi
```
instead of making it hard-dependent for all packages

I'll send the fixed one.

KISS :kissing_heart: 