### PR TITLE
Fix file conflict with egl-x11

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1983,7 +1983,7 @@ nvidia-utils-tkg() {
     elif [[ -e libnvidia-egl-xlib.so.1.0.3 ]]; then
       install -D -m755 "libnvidia-egl-xlib.so.1.0.3" "${pkgdir}/usr/lib/libnvidia-egl-xlib.so.1.0.3"
     fi
-    if (( ${pkgver%%.*} <= 580 )) && [[ -e 20_nvidia_xlib.json ]]; then
+    if (( ${pkgver%%.*} < 580 )) && [[ -e 20_nvidia_xlib.json ]]; then
       install -D -m644 "20_nvidia_xlib.json" "${pkgdir}/usr/share/egl/egl_external_platform.d/20_nvidia_xlib.json"
     fi
     if [[ -e libnvidia-egl-xcb.so.1 ]]; then
@@ -1995,7 +1995,7 @@ nvidia-utils-tkg() {
     elif [[ -e libnvidia-egl-xcb.so.1.0.3 ]]; then
       install -D -m755 "libnvidia-egl-xcb.so.1.0.3" "${pkgdir}/usr/lib/libnvidia-egl-xcb.so.1.0.3"
     fi
-    if (( ${pkgver%%.*} <= 580 )) && [[ -e 20_nvidia_xcb.json ]]; then
+    if (( ${pkgver%%.*} < 580 )) && [[ -e 20_nvidia_xcb.json ]]; then
       install -D -m644 "20_nvidia_xcb.json" "${pkgdir}/usr/share/egl/egl_external_platform.d/20_nvidia_xcb.json"
     fi
 


### PR DESCRIPTION
`depends+='egl-x11'` is set on >= 580, so these files should only be installed < 580
Probably requires another config entry like `_eglwayland` and `_eglgbm` as a proper fix, but this works for now