### PR TITLE
Nvidia udev rules adjusted

### DIFF
--- a/system/60-nvidia.rules
+++ b/system/60-nvidia.rules
@@ -9,7 +9,7 @@ ACTION=="add|bind", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", \
     RUN+="/usr/bin/nvidia-modprobe -c0 -u"
 
 # Enable runtime PM for NVIDIA VGA/3D controller devices
-ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", TEST=="power/control", ATTR{power/control}="auto"
+ACTION=="add|bind", SUBSYSTEM=="pci", DRIVERS=="nvidia", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", TEST=="power/control", ATTR{power/control}="auto"
 # Enable runtime PM for NVIDIA Audio devices
 ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", TEST=="power/control", ATTR{power/control}="auto"
 # Enable runtime PM for NVIDIA USB xHCI Host Controller devices
@@ -18,7 +18,7 @@ ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c0330
 ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c8000", TEST=="power/control", ATTR{power/control}="auto"
 
 # Disable runtime PM for NVIDIA VGA/3D controller devices
-ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", TEST=="power/control", ATTR{power/control}="on"
+ACTION=="remove|unbind", SUBSYSTEM=="pci", DRIVERS=="nvidia", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", TEST=="power/control", ATTR{power/control}="on"
 # Disable runtime PM for NVIDIA Audio devices
 ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", TEST=="power/control", ATTR{power/control}="on"
 # Disable runtime PM for NVIDIA USB xHCI Host Controller devices


### PR DESCRIPTION
Hi, here are my thoughts on this: Why this change?

Runtime power management for the NVIDIA GPU is now only applied when the NVIDIA driver is actually bound. This is done using `DRIVERS=="nvidia"` and the `add|bind` and `remove|unbind` events.

The result should be safer and more predictable runtime power management without duplicate or conflicting udev rules.

Am I seeing this correctly? :eyes:

❤️ 🐸 KISS