### PR TITLE
NVIDIA: ready for linux 6.19

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -489,7 +489,7 @@ md5sums=("$_md5sum"
          '411b490057cdd9e046ca6ea3d39b81bd' # limit-vram-usage
          '17c48c8ec5c19fd9582dedb9f0ad3ca2' # cuda-no-stable-perf-limit
          'f6d0a9b1e503d0e8c026a20b61f889c2'
-         'd0c82c7a74cc7cc5467aebf5a50238ee'
+         '0c0b692368eef7a511f22adddc23d8a2'
          '24bd1c8e7b9265020969a8da2962e114'
          '84ca49afabf4907f19c81e0bb56b5873'
          '5fd6eac00d4ab2ead6faa909482a6485')

--- a/patches/kernel-6.19.patch
+++ b/patches/kernel-6.19.patch
@@ -1,4 +1,4 @@
-From c4c6fadd3d61c6d66ba6026791571fb394ac27e2 Mon Sep 17 00:00:00 2001
+From c9457ce40a6af2ce74c520564e2d8775f49e3d27 Mon Sep 17 00:00:00 2001
 From: Eric Naim <dnaim@cachyos.org>
 Date: Thu, 18 Dec 2025 12:36:06 +0800
 Subject: [PATCH 3/3] Fix compile for 6.19
@@ -6,7 +6,9 @@ Subject: [PATCH 3/3] Fix compile for 6.19
 Contains:
 - Rename page_free callback -> folio_free callback for 6.19+
 - Adjust zone_device_page_init() call for 6.19; it has one extra argument now
+- 6.19-rc8 introduced yet another argument for zone_device_page_init()
 
+Link: https://github.com/torvalds/linux/commit/12b2285bf3d14372238d36215b73af02ac3bdfc1
 Signed-off-by: Eric Naim <dnaim@cachyos.org>
 ---
  kernel-open/nvidia-uvm/uvm_hmm.c     |  4 ++++
@@ -14,15 +16,15 @@ Signed-off-by: Eric Naim <dnaim@cachyos.org>
  2 files changed, 38 insertions(+)
 
 diff --git a/kernel-open/nvidia-uvm/uvm_hmm.c b/kernel-open/nvidia-uvm/uvm_hmm.c
-index 3e995e2dec76..5daf91ecb9b8 100644
+index 9b676f971385..22db001384a4 100644
 --- a/kernel-open/nvidia-uvm/uvm_hmm.c
 +++ b/kernel-open/nvidia-uvm/uvm_hmm.c
-@@ -2146,7 +2146,11 @@ static void fill_dst_pfn(uvm_va_block_t *va_block,
+@@ -2140,7 +2140,11 @@ static void fill_dst_pfn(uvm_va_block_t *va_block,
  
          UVM_ASSERT(!page_count(dpage));
          UVM_ASSERT(!dpage->zone_device_data);
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
-+        zone_device_page_init(dpage, 0);
++        zone_device_page_init(dpage, page_pgmap(dpage), 0);
 +#else
          zone_device_page_init(dpage);
 +#endif
@@ -30,10 +32,10 @@ index 3e995e2dec76..5daf91ecb9b8 100644
          atomic64_inc(&va_block->hmm.va_space->hmm.allocated_page_count);
      }
 diff --git a/kernel-open/nvidia-uvm/uvm_pmm_gpu.c b/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
-index cba0ec5397fe..191c26b47790 100644
+index 97ff13dcdd04..98423002776b 100644
 --- a/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
 +++ b/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
-@@ -175,6 +175,8 @@
+@@ -177,6 +177,8 @@
  #include "uvm_test.h"
  #include "uvm_linux.h"
  
@@ -42,7 +44,7 @@ index cba0ec5397fe..191c26b47790 100644
  #if defined(CONFIG_PCI_P2PDMA) && defined(NV_STRUCT_PAGE_HAS_ZONE_DEVICE_DATA)
  #include <linux/pci-p2pdma.h>
  #endif
-@@ -3115,8 +3117,14 @@ static bool uvm_pmm_gpu_check_orphan_pages(uvm_pmm_gpu_t *pmm)
+@@ -2999,8 +3001,14 @@ static bool uvm_pmm_gpu_check_orphan_pages(uvm_pmm_gpu_t *pmm)
      return ret;
  }
  
@@ -57,7 +59,7 @@ index cba0ec5397fe..191c26b47790 100644
      uvm_gpu_chunk_t *chunk = uvm_pmm_devmem_page_to_chunk(page);
      uvm_gpu_t *gpu = uvm_gpu_chunk_get_gpu(chunk);
  
-@@ -3177,7 +3185,11 @@ static vm_fault_t devmem_fault_entry(struct vm_fault *vmf)
+@@ -3060,7 +3068,11 @@ static vm_fault_t devmem_fault_entry(struct vm_fault *vmf)
  
  static const struct dev_pagemap_ops uvm_pmm_devmem_ops =
  {
@@ -69,7 +71,7 @@ index cba0ec5397fe..191c26b47790 100644
      .migrate_to_ram = devmem_fault_entry,
  };
  
-@@ -3265,8 +3277,14 @@ static void device_p2p_page_free_wake(struct nv_kref *ref)
+@@ -3148,8 +3160,14 @@ static void device_p2p_page_free_wake(struct nv_kref *ref)
      wake_up(&p2p_mem->waitq);
  }
  
@@ -84,7 +86,7 @@ index cba0ec5397fe..191c26b47790 100644
      uvm_device_p2p_mem_t *p2p_mem = page->zone_device_data;
  
      page->zone_device_data = NULL;
-@@ -3275,14 +3293,26 @@ static void device_p2p_page_free(struct page *page)
+@@ -3158,14 +3176,26 @@ static void device_p2p_page_free(struct page *page)
  #endif
  
  #if UVM_CDMM_PAGES_SUPPORTED()
@@ -111,7 +113,7 @@ index cba0ec5397fe..191c26b47790 100644
  };
  
  static NV_STATUS uvm_pmm_cdmm_init(uvm_parent_gpu_t *parent_gpu)
-@@ -3419,7 +3449,11 @@ static bool uvm_pmm_gpu_check_orphan_pages(uvm_pmm_gpu_t *pmm)
+@@ -3302,7 +3332,11 @@ static bool uvm_pmm_gpu_check_orphan_pages(uvm_pmm_gpu_t *pmm)
  
  static const struct dev_pagemap_ops uvm_device_p2p_pgmap_ops =
  {
@@ -125,4 +127,3 @@ index cba0ec5397fe..191c26b47790 100644
  void uvm_pmm_gpu_device_p2p_init(uvm_parent_gpu_t *parent_gpu)
 -- 
 2.52.0
-


### PR DESCRIPTION
Changes:

- Fix: add new kernel-6.19.patch
- Ref: https://gitlab.archlinux.org/archlinux/packaging/packages/nvidia-utils/-/blob/main/kernel-6.19.patch?ref_type=heads

KISS :frog: :kiss: 
