### PR TITLE
nvidia-470: add kernel 7.0 build patch

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -454,6 +454,7 @@ source=($_source_name
         '50-nvidia-cuda-disable-perf-boost.conf'
         'kernel-6.19.patch'
         'kernel-6.19-470.patch'
+        'kernel-7.0-470.patch'
         'kernel-7.0-580.patch'
         'kernel-7.0.patch'
         '0001-Enable-atomic-kernel-modesetting-by-default.diff'
@@ -537,6 +538,7 @@ md5sums=("$_md5sum"
         'f6d0a9b1e503d0e8c026a20b61f889c2'
         '0c0b692368eef7a511f22adddc23d8a2'
         '33d4a80f467ce96cd98b1d79aad720a5'
+        '40586f44fbf940c6b3dbcb1cfc25edae' # kernel-7.0-470.patch
         'ff72e6704d61ac2c85254e60780de2fc' # kernel-7.0-580.patch
         '5f3f509f22e574393baf424aefa5ad83' # kernel-7.0.patch
         '24bd1c8e7b9265020969a8da2962e114'
@@ -1246,6 +1248,12 @@ DEST_MODULE_LOCATION[3]="/kernel/drivers/video"' dkms.conf
       # 7.0
       if (( $(vercmp "$_kernel" "7.0") >= 0 )); then
         _whitelist70=( 590* 595* )
+        if [[ $pkgver = 470* ]]; then
+          cd "$srcdir"/"$_pkg"/kernel-$_kernel
+          msg2 "Applying kernel-7.0-470.patch for $_kernel..."
+          patch -Np1 -i "${srcdir}/kernel-7.0-470.patch"
+          cd ..
+        fi
         if (( ${pkgver%%.*} == 580 )); then
           cd "$srcdir"/"$_pkg"/kernel-$_kernel
           msg2 "Applying kernel-7.0-580.patch for $_kernel..."
@@ -1866,6 +1874,15 @@ DEST_MODULE_LOCATION[3]="/kernel/drivers/video"' dkms.conf
           cd "$srcdir"/"$_pkg"/kernel-dkms
           msg2 "Applying kernel-6.19-470.patch for $_kernel..."
           patch -Np1 -i "$srcdir"/kernel-6.19-470.patch
+        fi
+      fi
+
+      # 7.0
+      if (( $(vercmp "$_kernel" "7.0") >= 0 )); then
+        if [[ $pkgver = 470* ]]; then
+          cd "$srcdir"/"$_pkg"/kernel-dkms
+          msg2 "Applying kernel-7.0-470.patch for $_kernel..."
+          patch -Np1 -i "$srcdir"/kernel-7.0-470.patch
         fi
       fi
 

--- a/patches/kernel-7.0-470.patch
+++ b/patches/kernel-7.0-470.patch
@@ -1,0 +1,36 @@
+From 19a95a61ba1c3f1f2c7d9f47d8fd6206c7c8f4af Mon Sep 17 00:00:00 2001
+From: Peter Jung <admin@ptr1337.dev>
+Date: Sun, 19 Apr 2026 20:48:00 +0200
+Subject: [PATCH] Fix NVIDIA 470.256.02 for Linux 7.0 dma_fence_signal()
+
+Linux 7.0 changed dma_fence_signal() to return void. The legacy 470.xx
+driver still wraps that helper as int, which fails to compile when
+nvidia-drm is built against 7.0 headers.
+
+The wrapper's only caller ignores the return value, so make the helper
+void and discard the old return value on earlier kernels too.
+---
+ nvidia-drm/nvidia-dma-fence-helper.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/nvidia-drm/nvidia-dma-fence-helper.h b/nvidia-drm/nvidia-dma-fence-helper.h
+index 35bcf83..6fefd5d 100644
+--- a/nvidia-drm/nvidia-dma-fence-helper.h
++++ b/nvidia-drm/nvidia-dma-fence-helper.h
+@@ -89,11 +89,11 @@ nv_dma_fence_default_wait(nv_dma_fence_t *fence,
+ #endif
+ }
+ 
+-static inline int nv_dma_fence_signal(nv_dma_fence_t *fence) {
++static inline void nv_dma_fence_signal(nv_dma_fence_t *fence) {
+ #if defined(NV_LINUX_FENCE_H_PRESENT)
+-    return fence_signal(fence);
++    fence_signal(fence);
+ #else
+-    return dma_fence_signal(fence);
++    dma_fence_signal(fence);
+ #endif
+ }
+ 
+-- 
+2.52.0


### PR DESCRIPTION
Added a patch to support Kernel 7.0 build for NVIDIA 470 driver (untested). Thanks CachyOS!