### PR TITLE
arch: add kernel-install support to NVIDIA hooks

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -354,14 +354,14 @@ if [[ "${_dkms}" = "false" ]] || [[ "${_dkms}" = "full" ]]; then
             command -v mokutil >/dev/null 2>&1 &&
             mokutil --sb-state 2>/dev/null | grep -qi 'secure boot enabled'
         }; then
-        msg2 "Secure Boot is active or module signing is enabled — installing mkinitcpio signing hook"
+        msg2 "Secure Boot is active or module signing is enabled — installing module signing and initramfs update hook"
         install -Dm755 "${_where}/nvidia-all-config/module-signing" "${pkgdir}/usr/lib/nvidia-tkg/module-signing"
         install -Dm644 "${_where}/nvidia-all-config/system/nvidia-tkg-sign.hook" "${pkgdir}/usr/share/libalpm/hooks/nvidia-tkg.hook"
       else
         install -Dm644 "${_where}/nvidia-all-config/system/nvidia-tkg.hook" "${pkgdir}/usr/share/libalpm/hooks/nvidia-tkg.hook"
       fi
     else
-      msg2 "Skipping mkinitcpio hook due to user config"
+      msg2 "Skipping initramfs update hook due to user config"
     fi
   else
     pkgdesc="Full NVIDIA drivers' package for all kernels on the system (drivers and shared utilities and libraries)"
@@ -399,14 +399,14 @@ if [[ "${_dkms}" = "false" ]] || [[ "${_dkms}" = "full" ]]; then
             command -v mokutil >/dev/null 2>&1 &&
             mokutil --sb-state 2>/dev/null | grep -qi 'secure boot enabled'
         }; then
-        msg2 "Secure Boot is active or module signing is enabled — installing mkinitcpio signing hook"
+        msg2 "Secure Boot is active or module signing is enabled — installing module signing and initramfs update hook"
         install -Dm755 "${_where}/nvidia-all-config/module-signing" "${pkgdir}/usr/lib/nvidia-tkg/module-signing"
         install -Dm644 "${_where}/nvidia-all-config/system/nvidia-tkg-sign.hook" "${pkgdir}/usr/share/libalpm/hooks/nvidia-tkg.hook"
       else
         install -Dm644 "${_where}/nvidia-all-config/system/nvidia-tkg.hook" "${pkgdir}/usr/share/libalpm/hooks/nvidia-tkg.hook"
       fi
     else
-      msg2 "Skipping mkinitcpio hook due to user config"
+      msg2 "Skipping initramfs update hook due to user config"
     fi
   fi
 }
@@ -483,7 +483,7 @@ if [[ "${_dkms}" = "true" ]] || [[ "${_dkms}" = "full" ]]; then
       if [[ ! "${_disable_libalpm_hook}" == "true" ]]; then
         install -Dm644 "${_where}/nvidia-all-config/system/nvidia-tkg.hook" "${pkgdir}/usr/share/libalpm/hooks/nvidia-tkg.hook"
       else
-        msg2 "Skipping mkinitcpio hook due to user config"
+        msg2 "Skipping initramfs update hook due to user config"
       fi
 
       install -Dt "${pkgdir}/usr/share/licenses/${pkgname}" -m644 "${srcdir}/${_pkg}/LICENSE"

--- a/nvidia-all-config/system/nvidia-tkg-sign.hook
+++ b/nvidia-all-config/system/nvidia-tkg-sign.hook
@@ -13,7 +13,7 @@ Target=nvidia-open-tkg
 Target=nvidia-open-dkms-tkg
 
 [Action]
-Description=Sign Nvidia modules from linux-tkg headers and update initcpio
+Description=Sign Nvidia modules and refresh initramfs
 When=PostTransaction
 NeedsTargets
-Exec=/bin/sh -c 'if [ -x /usr/lib/nvidia-tkg/module-signing ]; then /usr/lib/nvidia-tkg/module-signing; fi; if command -v mkinitcpio >/dev/null 2>&1; then mkinitcpio -P; elif command -v /usr/lib/booster/regenerate_images >/dev/null 2>&1; then /usr/lib/booster/regenerate_images; elif command -v dracut >/dev/null 2>&1; then dracut --regenerate-all --force; else printf "\\033[31m The initramfs generator was not found, please update initramfs manually\\033[0m\\n"; fi'
+Exec=/bin/sh -c 'if [ -x /usr/lib/nvidia-tkg/module-signing ]; then /usr/lib/nvidia-tkg/module-signing; fi; if command -v mkinitcpio >/dev/null 2>&1 && find /etc/mkinitcpio.d -maxdepth 1 -type f -name "*.preset" -print -quit 2>/dev/null | grep -q .; then exec mkinitcpio -P; elif command -v kernel-install >/dev/null 2>&1 && kernel-install inspect --json=short 2>/dev/null | grep -Eq "\"Layout\":\"(uki|bls)\""; then exec kernel-install add-all; elif [ -x /usr/lib/booster/regenerate_images ]; then exec /usr/lib/booster/regenerate_images; elif command -v dracut >/dev/null 2>&1; then exec dracut --regenerate-all --force; else printf "\\033[31m The initramfs generator was not found, please update initramfs manually\\033[0m\\n"; fi'

--- a/nvidia-all-config/system/nvidia-tkg.hook
+++ b/nvidia-all-config/system/nvidia-tkg.hook
@@ -13,7 +13,7 @@ Target=nvidia-open-tkg
 Target=nvidia-open-dkms-tkg
 
 [Action]
-Description=Update Nvidia modules in initcpio
+Description=Update Nvidia modules in initramfs
 When=PostTransaction
 NeedsTargets
-Exec=/bin/sh -c 'if command -v mkinitcpio >/dev/null 2>&1; then mkinitcpio -P; elif command -v /usr/lib/booster/regenerate_images >/dev/null 2>&1; then /usr/lib/booster/regenerate_images; elif command -v dracut >/dev/null 2>&1; then dracut --regenerate-all --force; else printf "\\033[31m The initramfs generator was not found, please update initramfs manually\\033[0m\\n"; fi'
+Exec=/bin/sh -c 'if command -v mkinitcpio >/dev/null 2>&1 && find /etc/mkinitcpio.d -maxdepth 1 -type f -name "*.preset" -print -quit 2>/dev/null | grep -q .; then exec mkinitcpio -P; elif command -v kernel-install >/dev/null 2>&1 && kernel-install inspect --json=short 2>/dev/null | grep -Eq "\"Layout\":\"(uki|bls)\""; then exec kernel-install add-all; elif [ -x /usr/lib/booster/regenerate_images ]; then exec /usr/lib/booster/regenerate_images; elif command -v dracut >/dev/null 2>&1; then exec dracut --regenerate-all --force; else printf "\\033[31m The initramfs generator was not found, please update initramfs manually\\033[0m\\n"; fi'


### PR DESCRIPTION
The hooks always selected `mkinitcpio` when installed, even without active presets. This broke updates on systems using `kernel-install` for `UKI/BLS` and could leave their boot images stale.

- Add automatic `kernel-install` detection while keeping active `mkinitcpio` presets as the default.

Reference: [Arch kernel-install](https://wiki.archlinux.org/title/Kernel-install)